### PR TITLE
fix lldb debugger for ubuntu distros

### DIFF
--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -25,6 +25,7 @@
 
 import imp
 import os
+import platform
 from subprocess import CalledProcessError, check_output, STDOUT
 import sys
 
@@ -85,9 +86,17 @@ class LLDB(DebuggerBase):
                 sys.exc_info())
 
         if not os.path.isdir(pythonpath):
-            raise LoadDebuggerException(
-                'path "{}" does not exist [result of {}]'.format(
-                    pythonpath, args), sys.exc_info())
+            if "Ubuntu" in platform.linux_distribution():
+                pythonpath = os.path.join("/usr", "lib")
+                pythonpath = os.path.join(pythonpath, "llvm-6.0")
+                pythonpath = os.path.join(pythonpath, "lib")
+                pythonpath = os.path.join(pythonpath, "python2.7")
+                pythonpath = os.path.join(pythonpath, "site-packages")
+                # pythonpath = "/usr/lib/llvm-6.0/lib/python2.7/site-packages/"
+            else:
+                raise LoadDebuggerException(
+                    'path "{}" does not exist [result of {}]'.format(
+                        pythonpath, args), sys.exc_info())
 
         try:
             module_info = imp.find_module('lldb', [pythonpath])


### PR DESCRIPTION
Add out the box support for lldb on ubuntu distros.

Have run the lint and unit tests.

Again, python not my strong suit, appreciate any feedback on this.

I avoided using the python 3,x approach as wasn't sure if it would be supported on both 2.7 and 3.x.

happy reviewing
Tom