### PR TITLE
Allow environment to specify location of clang

### DIFF
--- a/dex/builder/scripts/posix/clang.sh
+++ b/dex/builder/scripts/posix/clang.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
+if test -z "$PATHTOCLANG"; then
+  PATHTOCLANG=clang++
+fi
+
 for INDEX in {SOURCE_INDEXES}
 do
   CFLAGS=$(eval echo "\$COMPILER_OPTIONS_$INDEX")
   SRCFILE=$(eval echo "\$SOURCE_FILE_$INDEX")
   OBJFILE=$(eval echo "\$OBJECT_FILE_$INDEX")
-  clang++ -std=gnu++11 -c $CFLAGS $SRCFILE -o $OBJFILE
+  $PATHTOCLANG -std=gnu++11 -c $CFLAGS $SRCFILE -o $OBJFILE
 done
 
-clang++ {LINKER_OPTIONS} {OBJECT_FILES} -o {EXECUTABLE_FILE}
+$PATHTOCLANG {LINKER_OPTIONS} {OBJECT_FILES} -o {EXECUTABLE_FILE}
 


### PR DESCRIPTION
When using dexters clang builder, it'd be useful to be able to specify
the location of the clang binary to use (a development or historic version
for example). Rather than passing it through the tool, specify it in the
environment as in this patch .