### PR TITLE
Add --binary option to the dexter test tool

### DIFF
--- a/dex/builder/ParserOptions.py
+++ b/dex/builder/ParserOptions.py
@@ -49,11 +49,14 @@ def _find_build_scripts():
 
 
 def add_builder_tool_arguments(parser):
+    parser.add_argument('--binary',
+                        metavar="<file>",
+                        help='provide binary file to override --builder')
+
     parser.add_argument(
         '--builder',
         type=str,
         choices=sorted(_find_build_scripts().keys()),
-        required=True,
         help='test builder to use')
     parser.add_argument(
         '--cflags', type=str, default='', help='compiler flags')

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -125,7 +125,7 @@ class LLDB(DebuggerBase):
 
     def launch(self):
         self._process = self._target.LaunchSimple(None, None, os.getcwd())
-        if not self._process:
+        if not self._process or self._process.GetNumThreads() == 0:
             raise DebuggerException('could not launch process')
         if self._process.GetNumThreads() != 1:
             raise DebuggerException('multiple threads not supported')


### PR DESCRIPTION
This option allows a user to specify a prebuilt binary to pass to the debugger.

Either or both of --builder and --binary options are required. --binary always
overrides --builder if both are given.

The test directory option is still required so that dexter can read in the
dexter commands (DexWatch etc).

This doesn't work with multiple tests as only one binary can be specified.
Ignoring this for now because the ability to run multiple tests will be
removed soon - see #15.