### PR TITLE
Add return codes for high level functions

### DIFF
--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -32,6 +32,7 @@ from dex.command import get_command_object
 from dex.dextIR import DebuggerIR
 from dex.utils.Exceptions import DebuggerException
 from dex.utils.Exceptions import NotYetLoadedDebuggerException
+from dex.utils.ReturnCode import ReturnCode
 
 
 class DebuggerBase(object, metaclass=abc.ABCMeta):
@@ -205,7 +206,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def go(self):
+    def go(self) -> ReturnCode:
         pass
 
     @abc.abstractmethod

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -31,6 +31,7 @@ import sys
 from dex.debugger.DebuggerBase import DebuggerBase
 from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
 from dex.utils.Exceptions import DebuggerException, LoadDebuggerException
+from dex.utils.ReturnCode import ReturnCode
 
 
 class LLDB(DebuggerBase):
@@ -134,8 +135,9 @@ class LLDB(DebuggerBase):
     def step(self):
         self._thread.StepInto()
 
-    def go(self):
+    def go(self) -> ReturnCode:
         self._process.Continue()
+        return ReturnCode.OK
 
     def get_step_info(self):
         frames = []

--- a/dex/debugger/visualstudio/VisualStudio.py
+++ b/dex/debugger/visualstudio/VisualStudio.py
@@ -30,6 +30,7 @@ import sys
 from dex.debugger.DebuggerBase import DebuggerBase
 from dex.dextIR import FrameIR, LocIR, StepIR, StopReason, ValueIR
 from dex.utils.Exceptions import LoadDebuggerException
+from dex.utils.ReturnCode import ReturnCode
 
 
 def _load_com_module():
@@ -131,8 +132,9 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
     def step(self):
         self._fn_step()
 
-    def go(self):
+    def go(self) -> ReturnCode:
         self._fn_go()
+        return ReturnCode.OK
 
     def get_step_info(self):
         thread = self._debugger.CurrentThread

--- a/dex/tools/Main.py
+++ b/dex/tools/Main.py
@@ -38,6 +38,7 @@ from dex.utils.Linting import linting_ok
 from dex.utils.UnitTests import unit_tests_ok
 from dex.utils.Version import version
 from dex.utils import WorkingDirectory
+from dex.utils.ReturnCode import ReturnCode
 
 
 def _output_bug_report_message(context):
@@ -159,7 +160,7 @@ def tool_main(context, tool, args):
 
         if options.version:
             context.o.green('{}\n'.format(context.version))
-            return 0
+            return ReturnCode.OK
 
         if (options.unittest != 'off' and not unit_tests_ok(context)):
             raise Error('<d>unit test failures</>')
@@ -169,7 +170,7 @@ def tool_main(context, tool, args):
 
         if options.colortest:
             context.o.colortest()
-            return 0
+            return ReturnCode.OK
 
         try:
             tool.handle_base_options(defaults)
@@ -178,8 +179,9 @@ def tool_main(context, tool, args):
 
         dir_ = context.options.working_directory
         with WorkingDirectory(context, dir=dir_) as context.working_directory:
-            tool.go()
-        return 0
+            return_code = tool.go()
+
+        return return_code
 
 
 class Context(object):
@@ -191,7 +193,7 @@ class Context(object):
         self.version: str = None
         self.root_directory: str = None
 
-def main():
+def main() -> ReturnCode:
 
     context = Context()
 
@@ -213,7 +215,7 @@ def main():
                     raise
             except AttributeError:
                 pass
-            return 1
+            return ReturnCode._ERROR
         except (KeyboardInterrupt, SystemExit):
             raise
         except:  # noqa

--- a/dex/tools/TestToolBase.py
+++ b/dex/tools/TestToolBase.py
@@ -34,6 +34,7 @@ from dex.heuristic.Heuristic import add_heuristic_tool_arguments
 from dex.tools.ToolBase import ToolBase
 from dex.utils import get_root_directory
 from dex.utils.Exceptions import Error, ToolArgumentError
+from dex.utils.ReturnCode import ReturnCode
 
 
 class TestToolBase(ToolBase):
@@ -93,7 +94,7 @@ class TestToolBase(ToolBase):
                     '<d>could not create directory</> <r>"{}"</> <y>({})</>'.
                     format(options.results_directory, e.strerror))
 
-    def go(self):  # noqa
+    def go(self) -> ReturnCode:  # noqa
         options = self.context.options
 
         subdirs = sorted([
@@ -116,7 +117,7 @@ class TestToolBase(ToolBase):
 
             self._run_test(subdir)
 
-        self._handle_results()
+        return self._handle_results()
 
     @staticmethod
     def _is_current_directory(test_directory):
@@ -138,5 +139,5 @@ class TestToolBase(ToolBase):
         pass
 
     @abc.abstractmethod
-    def _handle_results(self):
+    def _handle_results(self) -> ReturnCode:
         pass

--- a/dex/tools/ToolBase.py
+++ b/dex/tools/ToolBase.py
@@ -29,6 +29,7 @@ import tempfile
 from dex import __version__
 from dex.utils import ExtArgParse
 from dex.utils import PrettyOutput
+from dex.utils.ReturnCode import ReturnCode
 
 
 class ToolBase(object, metaclass=abc.ABCMeta):
@@ -152,5 +153,5 @@ class ToolBase(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def go(self):
+    def go(self) -> ReturnCode:
         pass

--- a/dex/tools/annotate_expected_values/Tool.py
+++ b/dex/tools/annotate_expected_values/Tool.py
@@ -28,6 +28,7 @@ import pickle
 from dex.dextIR.StepIR import StepKind
 from dex.tools import ToolBase
 from dex.utils.Exceptions import Error
+from dex.utils.ReturnCode import ReturnCode
 
 
 class ExpectedWatchValue(object):
@@ -134,7 +135,7 @@ class Tool(ToolBase):
                     raise Error('"{}" <d>is not a valid file</>'.format(sf))
                 raise Error('<d>could not find file</> "{}"'.format(sf))
 
-    def go(self):  # noqa
+    def go(self) -> ReturnCode:  # noqa
         options = self.context.options
 
         exp_values = set()
@@ -210,4 +211,4 @@ class Tool(ToolBase):
                     fp.write("\n// DexExpectStepKind('{}', {})".format(
                         step_kind.name, step_kind.count))
 
-        return 0
+        return ReturnCode.OK

--- a/dex/tools/clang_opt_bisect/Tool.py
+++ b/dex/tools/clang_opt_bisect/Tool.py
@@ -35,6 +35,7 @@ from dex.tools import TestToolBase
 from dex.utils.Exceptions import DebuggerException, Error
 from dex.utils.Exceptions import BuildScriptException, HeuristicException
 from dex.utils.PrettyOutputBase import Stream
+from dex.utils.ReturnCode import ReturnCode
 
 
 class BisectPass(object):
@@ -240,15 +241,15 @@ class Tool(TestToolBase):
         self._write_pass_summary(pass_summary_path,
                                  current_bisect_pass_summary)
 
-    def _handle_results(self):
+    def _handle_results(self) -> ReturnCode:
         options = self.context.options
         pass_summary_path = os.path.join(options.results_directory,
                                          'overall-pass-summary.csv')
 
         self._write_pass_summary(pass_summary_path,
                                  self._all_bisect_pass_summary)
+        return ReturnCode.OK
 
-        return 1
 
     def _clang_opt_bisect_build(self, opt_bisect_limits):
         options = self.context.options

--- a/dex/tools/help/Tool.py
+++ b/dex/tools/help/Tool.py
@@ -26,6 +26,7 @@ import imp
 import textwrap
 
 from dex.tools import ToolBase, get_tool_names, get_tools_directory, tool_main
+from dex.utils.ReturnCode import ReturnCode
 
 
 class Tool(ToolBase):
@@ -64,7 +65,7 @@ class Tool(ToolBase):
             s += '<g>{}</>\n{}\n\n'.format(tool_name, tool_doc)
         return s
 
-    def go(self):
+    def go(self) -> ReturnCode:
         if self.context.options.tool is None:
             self.context.o.auto(self._default_text)
             return 0

--- a/dex/tools/list_debuggers/Tool.py
+++ b/dex/tools/list_debuggers/Tool.py
@@ -28,6 +28,7 @@ from dex.debugger.Debuggers import Debuggers
 from dex.tools import ToolBase
 from dex.utils import Timer
 from dex.utils.Exceptions import DebuggerException, Error
+from dex.utils.ReturnCode import ReturnCode
 
 
 class Tool(ToolBase):
@@ -46,10 +47,10 @@ class Tool(ToolBase):
     def handle_options(self, defaults):
         handle_debugger_tool_options1(self.context, defaults)
 
-    def go(self):
+    def go(self) -> ReturnCode:
         with Timer('list debuggers'):
             try:
                 Debuggers(self.context).list()
             except DebuggerException as e:
                 raise Error(e)
-        return 0
+        return ReturnCode.OK

--- a/dex/tools/no_tool_/Tool.py
+++ b/dex/tools/no_tool_/Tool.py
@@ -26,6 +26,7 @@ It just provides a welcome message and simple usage instructions.
 
 from dex.tools import ToolBase, get_tool_names
 from dex.utils.Exceptions import Error
+from dex.utils.ReturnCode import ReturnCode
 
 
 # This is a special "tool" that is run when no subtool has been specified on
@@ -58,5 +59,7 @@ class Tool(ToolBase):
             raise Error('<d>no subtool specified</>\n\n{}\n'.format(
                 self.parser.format_help()))
 
-    def go(self):
-        return 1
+    def go(self) -> ReturnCode:
+        # This fn is never called because not specifying a subtool raises an
+        # exception.
+        return ReturnCode._ERROR

--- a/dex/tools/run_debugger_internal_/Tool.py
+++ b/dex/tools/run_debugger_internal_/Tool.py
@@ -31,6 +31,7 @@ from dex.debugger import Debuggers
 from dex.tools import ToolBase
 from dex.utils import Timer
 from dex.utils.Exceptions import DebuggerException, Error
+from dex.utils.ReturnCode import ReturnCode
 
 
 class Tool(ToolBase):
@@ -62,7 +63,7 @@ class Tool(ToolBase):
 
         Timer.display = self.context.options.time_report
 
-    def go(self):
+    def go(self) -> ReturnCode:
         options = self.context.options
 
         with Timer('loading debugger'):
@@ -87,3 +88,4 @@ class Tool(ToolBase):
 
         with open(self.context.options.dextIR_path, 'wb') as fp:
             pickle.dump(self.dextIR, fp)
+        return ReturnCode.OK

--- a/dex/tools/test/Tool.py
+++ b/dex/tools/test/Tool.py
@@ -33,6 +33,7 @@ from dex.tools import TestToolBase
 from dex.utils.Exceptions import DebuggerException
 from dex.utils.Exceptions import BuildScriptException, HeuristicException
 from dex.utils.PrettyOutputBase import Stream
+from dex.utils.ReturnCode import ReturnCode
 
 
 class TestCase(object):
@@ -204,7 +205,7 @@ class Tool(TestToolBase):
         self._record_successful_test(test_name, steps, heuristic_score)
         return
 
-    def _handle_results(self):
+    def _handle_results(self) -> ReturnCode:
         options = self.context.options
 
         if not options.verbose:
@@ -221,4 +222,4 @@ class Tool(TestToolBase):
                     test_case.error
                 ])
 
-        return 0
+        return ReturnCode.OK

--- a/dex/tools/view/Tool.py
+++ b/dex/tools/view/Tool.py
@@ -29,6 +29,8 @@ from dex.heuristic import Heuristic
 from dex.heuristic.Heuristic import add_heuristic_tool_arguments
 from dex.tools import ToolBase
 from dex.utils.Exceptions import Error, HeuristicException
+from dex.utils.ReturnCode import ReturnCode
+
 
 class Tool(ToolBase):
     """Given a dextIR file, display the information in a human-readable form.
@@ -56,7 +58,7 @@ class Tool(ToolBase):
             raise Error('<d>could not find dextIR file</> <r>"{}"</>'.format(
                 options.input_path))
 
-    def go(self):
+    def go(self) -> ReturnCode:
         options = self.context.options
 
         with open(options.input_path, 'rb') as fp:
@@ -70,4 +72,4 @@ class Tool(ToolBase):
         self.context.o.auto('{}\n\n{}\n\n{}\n\n'.format(
             heuristic.summary_string, steps, heuristic.verbose_output))
 
-        return 0
+        return ReturnCode.OK

--- a/dex/utils/ReturnCode.py
+++ b/dex/utils/ReturnCode.py
@@ -1,0 +1,9 @@
+from enum import Enum
+class ReturnCode(Enum):
+   OK = 0
+   _ERROR = 1        # Unhandled exceptions result in exit(1) by default.
+                     # Usage of _ERROR is discouraged:
+                     # If the program cannot run, raise an exception.
+                     # If the program runs successfully but the result is
+                     # "failure" based on the inputs, return FAIL
+   FAIL = 2

--- a/dexter.py
+++ b/dexter.py
@@ -27,6 +27,8 @@
 import sys
 
 from dex.tools import main
+from dex.utils.ReturnCode import ReturnCode
 
 if __name__ == '__main__':
-    sys.exit(main())
+    return_code = main()
+    sys.exit(return_code.value)


### PR DESCRIPTION
The return code is meant to represet program success on a high level.
It is not meant to replace exceptions.

The return code will is used as the program exit status.

OK(0)     - Normal termination, positive result
_ERROR(1) - Abnormal termination (usually an unhandled exception)
FAIL(2)   - Normal termination, negative result

This change will allow us to use the exit status to represent
whether a DExTer test has passed or failed. This feature is required
for debuginfo tests integration.