### PR TITLE
DexCommands are no longer callable

### DIFF
--- a/dex/command/CommandBase.py
+++ b/dex/command/CommandBase.py
@@ -33,5 +33,5 @@ class CommandBase(object, metaclass=abc.ABCMeta):
         self.lineno = None
 
     @abc.abstractmethod
-    def __call__(self):
+    def eval(self):
         pass

--- a/dex/command/commands/DexExpectStepKind.py
+++ b/dex/command/commands/DexExpectStepKind.py
@@ -42,5 +42,5 @@ class DexExpectStepKind(CommandBase):
 
         super(DexExpectStepKind, self).__init__()
 
-    def __call__(self):
+    def eval(self):
         pass

--- a/dex/command/commands/DexExpectStepOrder.py
+++ b/dex/command/commands/DexExpectStepOrder.py
@@ -9,7 +9,7 @@ class DexExpectStepOrder(CommandBase):
         self.sequence = [int(x) for x in args]
         super(DexExpectStepOrder, self).__init__()
 
-    def __call__(self, debugger):
+    def eval(self, debugger):
         step_info = debugger.get_step_info()
         loc = step_info.current_location
         return {'DexExpectStepOrder': ValueIR(expression=str(loc.lineno),

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -154,7 +154,7 @@ class DexExpectWatchValue(CommandBase):
         except KeyError:
             pass
 
-    def __call__(self, step_collection):
+    def eval(self, step_collection):
         for step in step_collection.steps:
             loc = step.current_location
 

--- a/dex/command/commands/DexUnreachable.py
+++ b/dex/command/commands/DexUnreachable.py
@@ -6,7 +6,7 @@ class DexUnreachable(CommandBase):
     super(DexUnreachable, self).__init__()
     pass
 
-  def __call__(self, debugger):
+  def eval(self, debugger):
     # If we're ever called, at all, then we're evaluating a line that has
     # been marked as unreachable. Which means a failure.
     vir = ValueIR(expression="Unreachable",

--- a/dex/command/commands/DexWatch.py
+++ b/dex/command/commands/DexWatch.py
@@ -39,5 +39,5 @@ class DexWatch(CommandBase):
         self._args = args
         super(DexWatch, self).__init__()
 
-    def __call__(self, debugger):
+    def eval(self, debugger):
         return {arg: debugger.evaluate_expression(arg) for arg in self._args}

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -119,7 +119,8 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
             for watch in towatch:
                 if (watch.loc.path == loc.path
                         and watch.loc.lineno == loc.lineno):
-                    step_info.watches.update(get_command_object(watch)(self))
+                    result = get_command_object(watch).eval(self)
+                    step_info.watches.update(result)
                     break
         except KeyError:
             pass

--- a/dex/heuristic/Heuristic.py
+++ b/dex/heuristic/Heuristic.py
@@ -138,7 +138,7 @@ class Heuristic(object):
         try:
             for watch in steps.commands["DexExpectWatchValue"]:
                 command = get_command_object(watch)
-                command(steps)
+                command.eval(steps)
                 maximum_possible_penalty = min(3, len(
                     command.values)) * worst_penalty
                 name, p = self._calculate_expect_watch_penalties(
@@ -159,7 +159,7 @@ class Heuristic(object):
         try:
             for step_kind in steps.commands['DexExpectStepKind']:
                 command = get_command_object(step_kind)
-                command()
+                command.eval()
                 # Cap the penalty at 2 * expected count or else 1
                 maximum_possible_penalty = max(command.count * 2, 1)
                 penalty = abs(command.count - step_kind_counts[command.name])


### PR DESCRIPTION
Abstract base method CommandBase.eval(self) should be implemented instead of
__call__(). This improves readability and makes it easier to search the
codebase.