### PR TITLE
Fix type confusion bewteen enums and text

### DIFF
--- a/dex/heuristic/Heuristic.py
+++ b/dex/heuristic/Heuristic.py
@@ -197,7 +197,7 @@ class Heuristic(object):
                 maximum_possible_penalty = max(command.count * 2, 1)
                 p = abs(command.count - step_kind_counts[command.name])
                 actual_penalty = min(p, maximum_possible_penalty)
-                key = (command.name
+                key = ('{}'.format(command.name)
                        if actual_penalty else '<g>{}</>'.format(command.name))
                 penalties[key] = [PenaltyInstance(p, actual_penalty)]
                 maximum_possible_penalty_all += maximum_possible_penalty


### PR DESCRIPTION
For whatever reasons, DexExpectStepKind names are now an enumeration;
one path through this function makes the 'key' variable a string, while
the other path uses the enumeration value. The result was a type
mismatch while ordering the dictionary at a latest date.

Solve this by forcing the use of a string down each path.