### PR TITLE
Remove a flakey assertion

### DIFF
--- a/dex/heuristic/Heuristic.py
+++ b/dex/heuristic/Heuristic.py
@@ -214,7 +214,6 @@ class Heuristic(object):
             ureachs = [
                 s for s in steps.steps if 'DexUnreachable' in s.watches.keys()
             ]
-            assert len(ureachs) <= len(cmds)
 
             # There's no need to match up cmds with the actual watches
             upen = self.penalty_unreachable


### PR DESCRIPTION
I originally stuck this in here to assert that the number of
"unreachable" lines never grew... however in reality, what this is
checking that the number of unreachable _steps_ is less than the number
of unreachable _commands_. This obviously croaks if one steps on an
unreachable line twice.