### PR TITLE
Cope with variable depth directory trees

### DIFF
--- a/dex/tools/test/Tool.py
+++ b/dex/tools/test/Tool.py
@@ -147,12 +147,20 @@ class Tool(TestToolBase):
         steps.builder = builderIR
         return steps
 
+    def _get_results_basename(self, test_name):
+        def splitall(x):
+            while len(x) > 0:
+              x, y = os.path.split(x)
+              yield y
+        all_components = reversed([x for x in splitall(test_name)])
+        return '_'.join(all_components)
+
     def _get_results_path(self, test_name):
         """Returns the path to the test results directory for the test denoted
            by test_name.
         """
-        return os.path.join(self.context.options.results_directory, '_'.join(
-            os.path.split(test_name)))
+        return os.path.join(self.context.options.results_directory,
+                            self._get_results_basename(test_name))
 
     def _get_results_text_path(self, test_name):
         """Returns path results .txt file for test denoted by test_name.
@@ -174,7 +182,8 @@ class Tool(TestToolBase):
         with open(output_text_path, 'w') as fp:
             self.context.o.auto(str(steps), stream=Stream(fp))
 
-        output_dextIR_path = '{}.dextIR'.format(test_name)
+        dextir_basename = self._get_results_basename(test_name)
+        output_dextIR_path = '{}.dextIR'.format(dextir_basename)
         with open(output_dextIR_path, 'wb') as fp:
             pickle.dump(steps, fp)
 


### PR DESCRIPTION
os.path.split will only split the basename of a path from the dirname,
it won't split the entire path. Two levels of test directories will thus
make path-separators turn up in file names.

Get around this with a generator that splits the path into components,
that are then joined with '_'. Use this file basename for writing the
dextir file too, as that risks having path separators in its name too.