### PR TITLE
Allow Dexter commands to specify subcommands

### DIFF
--- a/dex/command/CommandBase.py
+++ b/dex/command/CommandBase.py
@@ -35,3 +35,9 @@ class CommandBase(object, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def eval(self):
         pass
+
+    def get_subcommands() -> dict:
+        """Returns a dictionary of subcommands in the form {name: command} or
+        None if no subcommands are required.
+        """
+        return None

--- a/dex/command/ParseCommand.py
+++ b/dex/command/ParseCommand.py
@@ -32,6 +32,7 @@ import os
 
 from dex.command.CommandBase import CommandBase
 from dex.utils.Exceptions import CommandParseError
+from dex.dextIR import CommandIR
 
 
 def _get_valid_commands():
@@ -64,26 +65,41 @@ def _get_valid_commands():
         return commands
 
 
-def get_command_object(commandIR):
-    """Externally visible version of _safe_eval.  Only returns the Command
-    object itself.
-    """
-    valid_commands = _get_valid_commands()
-    # pylint: disable=eval-used
-    command = eval(commandIR.raw_text, valid_commands)
-    # pylint: enable=eval-used
-    command.path = commandIR.loc.path
-    command.lineno = commandIR.loc.lineno
-    return command
-
-
-def _get_command_name(command_raw):
+def _get_command_name(command_raw: str) -> str:
     """Return command name by splitting up DExTer command contained in
        command_raw on the first opening paranthesis and further stripping
        any potential leading or trailing whitespace.
     """
-    command_name = command_raw.split('(', 1)[0].rstrip()
-    return command_name
+    return command_raw.split('(', 1)[0].rstrip()
+
+
+def _merge_subcommands(command_name: str, valid_commands: dict) -> dict:
+    """Return a dict which merges valid_commands and subcommands for
+    command_name.
+    """
+    subcommands = valid_commands[command_name].get_subcommands()
+    if subcommands:
+        return { **valid_commands, **subcommands }
+    return valid_commands
+
+
+def _eval_command(command_raw: str, valid_commands: dict) -> CommandBase:
+    command_name = _get_command_name(command_raw)
+    valid_commands = _merge_subcommands(command_name, valid_commands)
+    # pylint: disable=eval-used
+    command = eval(command_raw, valid_commands)
+    # pylint: enable=eval-used
+    return command
+
+
+def get_command_object(commandIR: CommandIR):
+    """Externally visible version of _safe_eval.  Only returns the Command
+    object itself.
+    """
+    command = _eval_command(commandIR.raw_text, _get_valid_commands())
+    command.path = commandIR.loc.path
+    command.lineno = commandIR.loc.lineno
+    return command
 
 
 def _find_all_commands_in_file(path, file_lines, valid_commands):
@@ -106,9 +122,7 @@ def _find_all_commands_in_file(path, file_lines, valid_commands):
 
         to_eval = line[column:].rstrip()
         try:
-            # pylint: disable=eval-used
-            command = eval(to_eval, valid_commands)
-            # pylint: enable=eval-used
+            command = _eval_command(to_eval, valid_commands)
             command_name = _get_command_name(to_eval)
             command.path = path
             command.lineno = lineno


### PR DESCRIPTION
This allows additional globals to be passed to eval() without allowing the
user to call the subcommands globally in the test file.

This is required for #30. I can bundle the changes into that PR if necessary but I thought it might be clearer to separate them out.