### PR TITLE
Add multi-line command parsing

### DIFF
--- a/tests/nostdlib/gcd/test.cpp
+++ b/tests/nostdlib/gcd/test.cpp
@@ -17,5 +17,32 @@ int main()
 	return GCD(111, 259);
 }
 
-// DexExpectProgramState({'frames': [{'location': {'lineno': 11}, 'local_vars': {'lhs': '37', 'rhs': '0'}}, {'local_vars': {'lhs': '111', 'rhs': '37'}}, {'local_vars': {'lhs': '259', 'rhs': '111'}}, {'local_vars': {'lhs': '111', 'rhs': '259'}}]})
-
+/*
+DexExpectProgramState({
+	'frames': [
+		{
+			'location': {
+				'lineno': 11
+			},
+			'local_vars': {
+				'lhs': '37', 'rhs': '0'
+			}
+		},
+		{
+			'local_vars': {
+				'lhs': '111', 'rhs': '37'
+			}
+		},
+		{
+			'local_vars': {
+				'lhs': '259', 'rhs': '111'
+			}
+		},
+		{
+			'local_vars': {
+				'lhs': '111', 'rhs': '259'
+			}
+		}
+	]
+})
+*/


### PR DESCRIPTION
Commands can be split over multiple lines provided that there is no extraneous
text (e.g. C++ code) between the command's parentheses.