### PR TITLE
Add DexLabel support.

### DIFF
--- a/dex/command/CommandBase.py
+++ b/dex/command/CommandBase.py
@@ -32,6 +32,12 @@ class CommandBase(object, metaclass=abc.ABCMeta):
         self.path = None
         self.lineno = None
 
+    def get_label_args(self):
+        return list()
+
+    def has_labels(self):
+        return False
+
     @staticmethod
     @abc.abstractstaticmethod
     def get_name():

--- a/dex/command/ParseCommand.py
+++ b/dex/command/ParseCommand.py
@@ -53,15 +53,15 @@ def _get_valid_commands():
 
 def _get_command_name(command_raw: str) -> str:
     """Return command name by splitting up DExTer command contained in
-       command_raw on the first opening paranthesis and further stripping
-       any potential leading or trailing whitespace.
+    command_raw on the first opening paranthesis and further stripping
+    any potential leading or trailing whitespace.
     """
     return command_raw.split('(', 1)[0].rstrip()
 
 
 def _merge_subcommands(command_name: str, valid_commands: dict) -> dict:
     """Return a dict which merges valid_commands and subcommands for
-       command_name.
+    command_name.
     """
     subcommands = valid_commands[command_name].get_subcommands()
     if subcommands:

--- a/dex/command/ParseCommand.py
+++ b/dex/command/ParseCommand.py
@@ -84,7 +84,8 @@ def resolve_labels(command: CommandBase, commands: dict):
     command_label_args = command.get_label_args()
     for command_arg in command_label_args:
         for dex_label in list(dex_labels.values()):
-            if dex_label.path == command.path and dex_label.eval() == command_arg:
+            if (dex_label.path == command.path and
+                dex_label.eval() == command_arg):
                 command.resolve_label(dex_label.get_as_pair())
     # labels for command should be resolved by this point.
     if command.has_labels():
@@ -92,7 +93,9 @@ def resolve_labels(command: CommandBase, commands: dict):
         syntax_error.filename = command.path
         syntax_error.lineno = command.lineno
         syntax_error.offset = 0
-        syntax_error.text = command.__str__
+        syntax_error.msg = 'Unresolved labels'
+        for label in command.get_label_args():
+            syntax_error.msg += ' \'' + label + '\''
         raise syntax_error
 
 

--- a/dex/command/__init__.py
+++ b/dex/command/__init__.py
@@ -21,4 +21,4 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from dex.command.ParseCommand import find_all_commands, get_command_object
+from dex.command.ParseCommand import find_all_commands

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -141,6 +141,29 @@ class DexExpectWatchValue(CommandBase):
     def encountered_values(self):
         return sorted(list(set(self.values) - self._missing_values))
 
+
+    def resolve_label(self, label_line_pair):
+        # from_line and to_line could have the same label.
+        if self._to_line == label_line_pair[0]:
+            self._to_line = label_line_pair[1]
+        if self._from_line == label_line_pair[0]:
+             self._from_line = label_line_pair[1]
+
+    def has_labels(self):
+        return len(self.get_label_args()) > 0
+
+    def get_label_args(self):
+        label_list = []
+        try:
+            int(self._from_line)
+        except ValueError:
+            label_list.append(self._from_line)
+        try:
+            int(self._to_line)
+        except ValueError:
+            label_list.append(self._to_line)
+        return label_list
+
     def _handle_watch(self, step, watch):
         self.times_encountered += 1
 

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -144,23 +144,20 @@ class DexExpectWatchValue(CommandBase):
 
     def resolve_label(self, label_line_pair):
         # from_line and to_line could have the same label.
-        if self._to_line == label_line_pair[0]:
-            self._to_line = label_line_pair[1]
-        if self._from_line == label_line_pair[0]:
-             self._from_line = label_line_pair[1]
+        label, lineno = label_line_pair
+        if self._to_line == label:
+            self._to_line = lineno
+        if self._from_line == label:
+            self._from_line = lineno
 
     def has_labels(self):
         return len(self.get_label_args()) > 0
 
     def get_label_args(self):
         label_list = []
-        try:
-            int(self._from_line)
-        except ValueError:
+        if isinstance(self._from_line, str):
             label_list.append(self._from_line)
-        try:
-            int(self._to_line)
-        except ValueError:
+        if isinstance(self._to_line, str):
             label_list.append(self._to_line)
         return label_list
 

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -154,12 +154,8 @@ class DexExpectWatchValue(CommandBase):
         return len(self.get_label_args()) > 0
 
     def get_label_args(self):
-        label_list = []
-        if isinstance(self._from_line, str):
-            label_list.append(self._from_line)
-        if isinstance(self._to_line, str):
-            label_list.append(self._to_line)
-        return label_list
+        return [label for label in (self._from_line, self._to_line)
+                      if isinstance(label, str)]
 
     def _handle_watch(self, step, watch):
         self.times_encountered += 1

--- a/dex/command/commands/DexLabel.py
+++ b/dex/command/commands/DexLabel.py
@@ -1,7 +1,7 @@
 # DExTer : Debugging Experience Tester
 # ~~~~~~   ~         ~~         ~   ~~
 #
-# Copyright (c) 2018 by SN Systems Ltd., Sony Interactive Entertainment Inc.
+# Copyright (c) 2019 by SN Systems Ltd., Sony Interactive Entertainment Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,14 +20,28 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of a DExTer command embedded within one of the files under
-test.
+"""Command used to give a line in a test a named psuedonym. Every DexLabel has
+   a line number and Label string component.
 """
 
-from dex.dextIR.LocIR import LocIR
+from dex.command.CommandBase import CommandBase
 
 
-class CommandIR:
-    def __init__(self, raw_text: str, loc: LocIR):
-        self.raw_text = raw_text
-        self.loc = loc
+class DexLabel(CommandBase):
+    def __init__(self, label):
+
+        if not isinstance(label, str):
+            raise TypeError('invalid argument type')
+
+        self._label = label
+        super(DexLabel, self).__init__()
+
+    def get_as_pair(self):
+        return (self._label, self.lineno)
+
+    @staticmethod
+    def get_name():
+        return __class__.__name__
+
+    def eval(self):
+        return self._label

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -137,8 +137,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         self.steps.clear_steps()
         self.launch()
 
-        for command in chain.from_iterable(self.steps.commands.values()):
-            command_obj = get_command_object(command)
+        for command_obj in chain.from_iterable(self.steps.commands.values()):
             self.watches.update(command_obj.get_watches())
 
         max_steps = self.context.options.max_steps

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -28,7 +28,6 @@ import sys
 import time
 import traceback
 
-from dex.command import get_command_object
 from dex.dextIR import DebuggerIR
 from dex.utils.Exceptions import DebuggerException
 from dex.utils.Exceptions import NotYetLoadedDebuggerException
@@ -117,9 +116,9 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         try:
             # Iterate over all watches of the types named in watch_cmds
             for watch in towatch:
-                if (watch.loc.path == loc.path
-                        and watch.loc.lineno == loc.lineno):
-                    result = get_command_object(watch).eval(self)
+                if (watch.path == loc.path
+                        and watch.lineno == loc.lineno):
+                    result = watch.eval(self)
                     step_info.watches.update(result)
                     break
         except KeyError:

--- a/dex/debugger/Debuggers.py
+++ b/dex/debugger/Debuggers.py
@@ -30,7 +30,7 @@ import sys
 from tempfile import NamedTemporaryFile
 
 from dex.command import find_all_commands
-from dex.dextIR import CommandIR, DextIR, LocIR
+from dex.dextIR import DextIR
 from dex.utils import get_root_directory, Timer
 from dex.utils.Environment import is_native_windows
 from dex.utils.Exceptions import CommandParseError, DebuggerException
@@ -150,10 +150,7 @@ def _get_command_infos(context):
         for command in commands[command_type].values():
             if command_type not in command_infos:
                 command_infos[command_type] = []
-
-            loc = LocIR(path=command.path, lineno=command.lineno, column=None)
-            command_infos[command_type].append(
-                CommandIR(loc=loc, raw_text=command.raw_text))
+            command_infos[command_type].append(command)
     return OrderedDict(command_infos)
 
 

--- a/dex/debugger/visualstudio/VisualStudio.py
+++ b/dex/debugger/visualstudio/VisualStudio.py
@@ -179,8 +179,9 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
             frames.append(frame)
 
         loc = LocIR(**self._location)
-        frames[0].loc = loc
-        state_frames[0].location = SourceLocation(**self._location)
+        if frames:
+            frames[0].loc = loc
+            state_frames[0].location = SourceLocation(**self._location)
 
         reason = StopReason.BREAKPOINT
         if loc.path is None:  # pylint: disable=no-member

--- a/dex/dextIR/__init__.py
+++ b/dex/dextIR/__init__.py
@@ -30,5 +30,4 @@ from dex.dextIR.FrameIR import FrameIR
 from dex.dextIR.LocIR import LocIR
 from dex.dextIR.StepIR import StepIR, StepKind, StopReason
 from dex.dextIR.ValueIR import ValueIR
-from dex.dextIR.CommandIR import CommandIR
 from dex.dextIR.ProgramState import ProgramState, SourceLocation, StackFrame

--- a/dex/heuristic/Heuristic.py
+++ b/dex/heuristic/Heuristic.py
@@ -31,7 +31,6 @@ import difflib
 import os
 from itertools import groupby
 from dex.command.commands.DexExpectWatchValue import StepValueInfo
-from dex.command.ParseCommand import get_command_object
 
 
 PenaltyCommand = namedtuple('PenaltyCommand', ['pen_dict', 'max_penalty'])
@@ -128,8 +127,7 @@ class Heuristic(object):
 
         # Get DexExpectWatchValue results.
         try:
-            for watch in steps.commands["DexExpectWatchValue"]:
-                command = get_command_object(watch)
+            for command in steps.commands['DexExpectWatchValue']:
                 command.eval(steps)
                 maximum_possible_penalty = min(3, len(
                     command.values)) * worst_penalty
@@ -143,8 +141,7 @@ class Heuristic(object):
         try:
             penalties = defaultdict(list)
             maximum_possible_penalty_all = 0
-            for command in steps.commands["DexExpectProgramState"]:
-                expect_state = get_command_object(command)
+            for expect_state in steps.commands['DexExpectProgramState']:
                 success = expect_state.eval(steps)
                 p = 0 if success else self.penalty_incorrect_program_state
 
@@ -175,8 +172,7 @@ class Heuristic(object):
         penalties = defaultdict(list)
         maximum_possible_penalty_all = 0
         try:
-            for step_kind in steps.commands['DexExpectStepKind']:
-                command = get_command_object(step_kind)
+            for command in steps.commands['DexExpectStepKind']:
                 command.eval()
                 # Cap the penalty at 2 * expected count or else 1
                 maximum_possible_penalty = max(command.count * 2, 1)
@@ -219,11 +215,10 @@ class Heuristic(object):
 
         if 'DexExpectStepOrder' in steps.commands:
             cmds = steps.commands['DexExpectStepOrder']
-            cmds = [(c, get_command_object(c)) for c in cmds]
 
             # Form a list of which line/cmd we _should_ have seen
-            cmd_num_lst = [(x, c.loc.lineno) for c, co in cmds
-                           for x in co.sequence]
+            cmd_num_lst = [(x, c.lineno) for c in cmds
+                                         for x in c.sequence]
             # Order them by the sequence number
             cmd_num_lst.sort(key=lambda t: t[0])
             # Strip out sequence key

--- a/dexter.py
+++ b/dexter.py
@@ -27,7 +27,6 @@
 import sys
 
 from dex.tools import main
-from dex.utils.ReturnCode import ReturnCode
 
 if __name__ == '__main__':
     return_code = main()


### PR DESCRIPTION
Specify a DexLabel('myLabel') on any line of a test and you can now reference
said label within a DexExpectWatchValue('myVar', '1', '2', on_line='myLabel').

In order to preserve label values resolved at the point of parsing a command, the way in which we pass DexCommands around DExTer has needed to be re-jigged a little.

The original implementation would store a CommandIR with LocIR for each command, an abstraction of the raw text and the location information for each command. The raw text part was evaled throughout DExTer for different purposes, mainly in the run_internal_debugger tool and heuristic.

This is now no longer the case. DexCommands are now stored as objects and are passed around as such. The only exception being within the run_internal_debugger tool which loads them from previously pickled data.

As a result there are several changes in this patch that are there to support the use of command objects rather than CommandIR, which has now been removed from DExTer.