### PR TITLE
Remove watch commands, allow arbitrary expressions in Program State

### DIFF
--- a/dex/command/CommandBase.py
+++ b/dex/command/CommandBase.py
@@ -26,6 +26,7 @@ which will then be executed by DExTer during debugging.
 """
 
 import abc
+from typing import List
 
 class CommandBase(object, metaclass=abc.ABCMeta):
     def __init__(self):
@@ -38,6 +39,9 @@ class CommandBase(object, metaclass=abc.ABCMeta):
         """This abstract method is usually implemented in subclasses as:
            return __class__.__name__
         """
+
+    def get_watches(self) -> List[str]:
+        return []
 
     @abc.abstractmethod
     def eval(self):

--- a/dex/command/commands/DexExpectProgramState.py
+++ b/dex/command/commands/DexExpectProgramState.py
@@ -24,6 +24,8 @@
 during execution.
 """
 
+from itertools import chain
+
 from dex.command.CommandBase import CommandBase
 from dex.dextIR import ProgramState, SourceLocation, StackFrame, DextIR
 
@@ -61,6 +63,11 @@ class DexExpectProgramState(CommandBase):
     @staticmethod
     def get_name():
         return __class__.__name__
+
+    def get_watches(self):
+        frame_expects = chain.from_iterable(iter(frame.local_vars)
+            for frame in self.expected_program_state.frames)
+        return set(frame_expects)
 
     def eval(self, step_collection: DextIR) -> bool:
         for step in step_collection.steps:

--- a/dex/command/commands/DexExpectProgramState.py
+++ b/dex/command/commands/DexExpectProgramState.py
@@ -65,7 +65,7 @@ class DexExpectProgramState(CommandBase):
         return __class__.__name__
 
     def get_watches(self):
-        frame_expects = chain.from_iterable(iter(frame.local_vars)
+        frame_expects = chain.from_iterable(iter(frame.watches)
             for frame in self.expected_program_state.frames)
         return set(frame_expects)
 

--- a/dex/command/commands/DexExpectProgramState.py
+++ b/dex/command/commands/DexExpectProgramState.py
@@ -65,7 +65,7 @@ class DexExpectProgramState(CommandBase):
         return __class__.__name__
 
     def get_watches(self):
-        frame_expects = chain.from_iterable(iter(frame.watches)
+        frame_expects = chain.from_iterable(frame.watches
             for frame in self.expected_program_state.frames)
         return set(frame_expects)
 

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -183,7 +183,7 @@ class DexExpectWatchValue(CommandBase):
 
             if (loc.path == self.path and loc.lineno in self.line_range):
                 try:
-                    watch = step.program_state.frames[0].local_vars[self.expression]
+                    watch = step.program_state.frames[0].watches[self.expression]
                 except KeyError:
                     pass
                 else:

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -129,6 +129,10 @@ class DexExpectWatchValue(CommandBase):
 
         super(DexExpectWatchValue, self).__init__()
 
+
+    def get_watches(self):
+        return [self.expression]
+
     @property
     def line_range(self):
         return list(range(self._from_line, self._to_line + 1))
@@ -179,7 +183,7 @@ class DexExpectWatchValue(CommandBase):
 
             if (loc.path == self.path and loc.lineno in self.line_range):
                 try:
-                    watch = step.watches[self.expression]
+                    watch = step.program_state.frames[0].local_vars[self.expression]
                 except KeyError:
                     pass
                 else:

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -42,6 +42,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         self._interface = None
         self.has_loaded = False
         self._loading_error = NotYetLoadedDebuggerException()
+        self.watches = set()
 
         try:
             self._interface = self._load_interface()
@@ -136,6 +137,10 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         self.steps.clear_steps()
         self.launch()
 
+        for command in chain.from_iterable(self.steps.commands.values()):
+            command_obj = get_command_object(command)
+            self.watches = self.watches.union(command_obj.get_watches())
+
         max_steps = self.context.options.max_steps
         for _ in range(max_steps):
             while self.is_running:
@@ -148,7 +153,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
             step_info = self.get_step_info()
 
             if step_info.current_frame:
-                self._update_step_watches(step_info)
+                # self._update_step_watches(step_info)
                 self.steps.new_step(self.context, step_info)
 
             if (step_info.current_frame

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -111,7 +111,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
 
     def _update_step_watches(self, step_info):
         loc = step_info.current_location
-        watch_cmds = ['DexWatch', 'DexUnreachable', 'DexExpectStepOrder']
+        watch_cmds = ['DexUnreachable', 'DexExpectStepOrder']
         towatch = chain.from_iterable(self.steps.commands[x]
                                       for x in watch_cmds
                                       if x in self.steps.commands)
@@ -153,7 +153,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
             step_info = self.get_step_info()
 
             if step_info.current_frame:
-                # self._update_step_watches(step_info)
+                self._update_step_watches(step_info)
                 self.steps.new_step(self.context, step_info)
 
             if (step_info.current_frame

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -232,5 +232,5 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def evaluate_expression(self, expression):
+    def evaluate_expression(self, expression, frame_idx=0):
         pass

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -139,7 +139,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
 
         for command in chain.from_iterable(self.steps.commands.values()):
             command_obj = get_command_object(command)
-            self.watches = self.watches.union(command_obj.get_watches())
+            self.watches.update(command_obj.get_watches())
 
         max_steps = self.context.options.max_steps
         for _ in range(max_steps):

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -29,7 +29,7 @@ import time
 import traceback
 
 from dex.command import get_command_object
-from dex.dextIR import DebuggerIR
+from dex.dextIR import DebuggerIR, ValueIR
 from dex.utils.Exceptions import DebuggerException
 from dex.utils.Exceptions import NotYetLoadedDebuggerException
 from dex.utils.ReturnCode import ReturnCode
@@ -232,5 +232,5 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def evaluate_expression(self, expression, frame_idx=0):
+    def evaluate_expression(self, expression, frame_idx=0) -> ValueIR:
         pass

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -177,9 +177,9 @@ class LLDB(DebuggerBase):
             state_frame = StackFrame(function=frame.function,
                                      is_inlined=frame.is_inlined,
                                      location=SourceLocation(**loc_dict),
-                                     local_vars={})
+                                     watches={})
             for expr in map(lambda watch, idx=i: self.evaluate_expression(watch, idx), self.watches):
-                state_frame.local_vars[expr.expression] = expr
+                state_frame.watches[expr.expression] = expr
             state_frames.append(state_frame)
 
         if len(frames) == 1 and frames[0].function is None:

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -207,7 +207,7 @@ class LLDB(DebuggerBase):
     def frames_below_main(self):
         return ['__scrt_common_main_seh', '__libc_start_main']
 
-    def evaluate_expression(self, expression, frame_idx=0):
+    def evaluate_expression(self, expression, frame_idx=0) -> ValueIR:
         result = self._thread.GetFrameAtIndex(frame_idx
             ).EvaluateExpression(expression)
         error_string = str(result.error)

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -143,7 +143,6 @@ class LLDB(DebuggerBase):
     def get_step_info(self):
         frames = []
         state_frames = []
-        print(self.watches)
 
         for i in range(0, self._thread.GetNumFrames()):
             sb_frame = self._thread.GetFrameAtIndex(i)

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -208,7 +208,8 @@ class LLDB(DebuggerBase):
         return ['__scrt_common_main_seh', '__libc_start_main']
 
     def evaluate_expression(self, expression, frame_idx=0):
-        result = self._thread.GetFrameAtIndex(frame_idx).EvaluateExpression(expression)
+        result = self._thread.GetFrameAtIndex(frame_idx
+            ).EvaluateExpression(expression)
         error_string = str(result.error)
 
         value = result.value

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -178,7 +178,9 @@ class LLDB(DebuggerBase):
                                      is_inlined=frame.is_inlined,
                                      location=SourceLocation(**loc_dict),
                                      watches={})
-            for expr in map(lambda watch, idx=i: self.evaluate_expression(watch, idx), self.watches):
+            for expr in map(
+                lambda watch, idx=i: self.evaluate_expression(watch, idx),
+                self.watches):
                 state_frame.watches[expr.expression] = expr
             state_frames.append(state_frame)
 

--- a/dex/debugger/visualstudio/VisualStudio.py
+++ b/dex/debugger/visualstudio/VisualStudio.py
@@ -169,7 +169,7 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
 
             state_frame = StackFrame(function=frame.function,
                                      is_inlined=frame.is_inlined,
-                                     local_vars={})
+                                     watches={})
 
             if idx == 0:
                 frame.loc = loc
@@ -177,7 +177,7 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
 
             self.set_current_stack_frame(idx)
             for watch in self.watches:
-                state_frame.local_vars[watch] = self.evaluate_expression(
+                state_frame.watches[watch] = self.evaluate_expression(
                     watch)
             self.set_current_stack_frame(0)
 

--- a/dex/debugger/visualstudio/VisualStudio.py
+++ b/dex/debugger/visualstudio/VisualStudio.py
@@ -175,11 +175,9 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
                 frame.loc = loc
                 state_frame.location = SourceLocation(**self._location)
 
-            self.set_current_stack_frame(idx)
             for watch in self.watches:
                 state_frame.watches[watch] = self.evaluate_expression(
-                    watch)
-            self.set_current_stack_frame(0)
+                    watch, idx)
 
 
             state_frames.append(state_frame)
@@ -210,8 +208,10 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
             '__tmainCRTStartup', 'mainCRTStartup'
         ]
 
-    def evaluate_expression(self, expression) -> ValueIR:
+    def evaluate_expression(self, expression, frame_idx=0) -> ValueIR:
+        self.set_current_stack_frame(frame_idx)
         result = self._debugger.GetExpression(expression)
+        self.set_current_stack_frame(0)
         value = result.Value
 
         is_optimized_away = any(s in value for s in [

--- a/dex/debugger/visualstudio/VisualStudio.py
+++ b/dex/debugger/visualstudio/VisualStudio.py
@@ -154,7 +154,6 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
         frames = []
         state_frames = []
 
-        loc = LocIR(**self._location)
 
         for idx, sf in enumerate(stackframes):
             frame = FrameIR(
@@ -171,10 +170,6 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
                                      is_inlined=frame.is_inlined,
                                      watches={})
 
-            if idx == 0:
-                frame.loc = loc
-                state_frame.location = SourceLocation(**self._location)
-
             for watch in self.watches:
                 state_frame.watches[watch] = self.evaluate_expression(
                     watch, idx)
@@ -182,6 +177,10 @@ class VisualStudio(DebuggerBase, metaclass=abc.ABCMeta):  # pylint: disable=abst
 
             state_frames.append(state_frame)
             frames.append(frame)
+
+        loc = LocIR(**self._location)
+        frames[0].loc = loc
+        state_frames[0].location = SourceLocation(**self._location)
 
         reason = StopReason.BREAKPOINT
         if loc.path is None:  # pylint: disable=no-member

--- a/dex/dextIR/ProgramState.py
+++ b/dex/dextIR/ProgramState.py
@@ -41,6 +41,9 @@ class SourceLocation:
         return '{}({}:{})'.format(self.path, self.lineno, self.column)
 
     def match(self, other) -> bool:
+        """Returns true iff all the properties that appear in `self` have the
+        same value in `other`, but not necessarily vice versa.
+        """
         if not other or not isinstance(other, SourceLocation):
             return False
 
@@ -75,9 +78,12 @@ class StackFrame:
             self.function,
             ' (inlined)' if self.is_inlined else '',
             self.location,
-            self.local_vars)
+            {k: str(self.local_vars[k]) for k in self.local_vars})
 
     def match(self, other) -> bool:
+        """Returns true iff all the properties that appear in `self` have the
+        same value in `other`, but not necessarily vice versa.
+        """
         if not other or not isinstance(other, StackFrame):
             return False
 
@@ -87,7 +93,7 @@ class StackFrame:
         if self.local_vars:
             for name in iter(self.local_vars):
                 try:
-                    if other.local_vars[name] != self.local_vars[name]:
+                    if other.local_vars[name].value != self.local_vars[name]:
                         return False
                 except KeyError:
                     return False
@@ -95,11 +101,8 @@ class StackFrame:
         return True
 
 class ProgramState:
-    def __init__(self,
-                 frames: List[StackFrame] = None,
-                 global_vars: OrderedDict = None):
+    def __init__(self, frames: List[StackFrame] = None):
         self.frames = frames
-        self.global_vars = global_vars
 
     def __str__(self):
         return '\n'.join(map(
@@ -107,6 +110,9 @@ class ProgramState:
             enumerate(self.frames)))
 
     def match(self, other) -> bool:
+        """Returns true iff all the properties that appear in `self` have the
+        same value in `other`, but not necessarily vice versa.
+        """
         if not other or not isinstance(other, ProgramState):
             return False
 
@@ -116,14 +122,6 @@ class ProgramState:
                     if not frame.match(other.frames[idx]):
                         return False
                 except (IndexError, KeyError):
-                    return False
-
-        if self.global_vars:
-            for name in iter(self.global_vars):
-                try:
-                    if other.global_variables[name] != self.global_vars[name]:
-                        return False
-                except IndexError:
                     return False
 
         return True

--- a/dex/dextIR/ProgramState.py
+++ b/dex/dextIR/ProgramState.py
@@ -64,21 +64,21 @@ class StackFrame:
                  function: str = None,
                  is_inlined: bool = None,
                  location: SourceLocation = None,
-                 local_vars: OrderedDict = None):
-        if local_vars is None:
-            local_vars = {}
+                 watches: OrderedDict = None):
+        if watches is None:
+            watches = {}
 
         self.function = function
         self.is_inlined = is_inlined
         self.location = location
-        self.local_vars = local_vars
+        self.watches = watches
 
     def __str__(self):
         return '{}{}: {} | {}'.format(
             self.function,
             ' (inlined)' if self.is_inlined else '',
             self.location,
-            {k: str(self.local_vars[k]) for k in self.local_vars})
+            {k: str(self.watches[k]) for k in self.watches})
 
     def match(self, other) -> bool:
         """Returns true iff all the properties that appear in `self` have the
@@ -90,10 +90,10 @@ class StackFrame:
         if self.location and not self.location.match(other.location):
             return False
 
-        if self.local_vars:
-            for name in iter(self.local_vars):
+        if self.watches:
+            for name in iter(self.watches):
                 try:
-                    if other.local_vars[name].value != self.local_vars[name]:
+                    if other.watches[name].value != self.watches[name]:
                         return False
                 except KeyError:
                     return False

--- a/dex/dextIR/ValueIR.py
+++ b/dex/dextIR/ValueIR.py
@@ -41,3 +41,6 @@ class ValueIR:
         self.error_string = error_string
         self.is_optimized_away = is_optimized_away
         self.is_irretrievable = is_irretrievable
+
+    def __str__(self):
+        return self.value

--- a/dex/dextIR/ValueIR.py
+++ b/dex/dextIR/ValueIR.py
@@ -41,6 +41,3 @@ class ValueIR:
         self.error_string = error_string
         self.is_optimized_away = is_optimized_away
         self.is_irretrievable = is_irretrievable
-
-    def __str__(self):
-        return self.value

--- a/tests/nostdlib/gcd/test.cpp
+++ b/tests/nostdlib/gcd/test.cpp
@@ -24,22 +24,22 @@ DexExpectProgramState({
 			'location': {
 				'lineno': 11
 			},
-			'local_vars': {
+			'watches': {
 				'lhs': '37', 'rhs': '0'
 			}
 		},
 		{
-			'local_vars': {
+			'watches': {
 				'lhs': '111', 'rhs': '37'
 			}
 		},
 		{
-			'local_vars': {
+			'watches': {
 				'lhs': '259', 'rhs': '111'
 			}
 		},
 		{
-			'local_vars': {
+			'watches': {
 				'lhs': '111', 'rhs': '259'
 			}
 		}


### PR DESCRIPTION
Does not include the actual removal of DexWatch (although it no longer does anything) or of DexWatch from tests, as these changes are trivial but amount to a very large diff which is unnecessary for a practical review of the change.