### PR TITLE
Improve documentation

### DIFF
--- a/Commands.md
+++ b/Commands.md
@@ -30,17 +30,20 @@
                       ]}
 
     Keyword args:
-        times (int): Minumum number of ime this state pattern is expected to be
-            seen. Defaults to 1. Can be 0.
+        times (int): Minimum number of times this state pattern is expected to
+             be seen. Defaults to 1. Can be 0.
 
 ### Description
-Expect to see a given program `state` a certain numer of `times`.
+Expect to see a given program `state` a certain number of `times`.
 
-When matching expected against reported states:
-* Omitted fields in `StackFrame` and `SourceLocation` dictionaries are ignored.
-* The state match fails if the results of each `expr` in `watches`
-does not match the given `value`.
+For every debugger step the reported state is compared with the expected state.
+To consider the states a match:
 
+* The `SourceLocation` must match in both states. Omitted fields in the
+`SourceLocation` dictionary are ignored; they always match.
+* Each `expr` in `watches` in the expected state must evaluate to the given
+`value`.
+* The function name and inline status are not considered.
 
 ### Heuristic
 [TODO]

--- a/Commands.md
+++ b/Commands.md
@@ -70,14 +70,14 @@ through the program.
 
 ---
 ## DexExpectStepOrder
-    DexExpectStepOrder(index)
+    DexExpectStepOrder(*order)
 
-    Args:
-      index (int): Position in sequence of DexExpectStepOrder commands
+    Arg list:
+      order (int): One or more indices.
 
 ### Description
-Expect the line this command is found on to be stepped on before all other
-DexExpectStepOrder commands with a greater `index` argument.
+Expect the line every `DexExpectStepOrder` is found on to be stepped on in
+`order`. Each instance must have a set of unique ascending indicies.
 
 ### Heuristic
 [TODO]
@@ -85,8 +85,8 @@ DexExpectStepOrder commands with a greater `index` argument.
 
 ---
 ## DexExpectWatchValue
-    DexExpectWatchValue(expr, *values[,**from_line=1][,**to_line=Max]
-                        [,**on_line])
+    DexExpectWatchValue(expr, *values [,**from_line=1][,**to_line=Max]
+                        [,**on_line][,**require_in_order=True])
 
     Args:
         expr (str): C++ expression to evaluate.
@@ -100,6 +100,7 @@ DexExpectStepOrder commands with a greater `index` argument.
             source.
         on_line (int): Only evaluate the expression on this line. If provided,
             this overrides from_line and to_line.
+        require_in_order (bool): If False the values can appear in any order.
 
 ### Description
 Expect the C++ expression `expr` to evaluate to the list of `values`

--- a/Commands.md
+++ b/Commands.md
@@ -1,0 +1,150 @@
+# Dexter commands
+
+* [DexExpectProgramState](Commands.md#DexExpectProgramState)
+* [DexExpectStepKind](Commands.md#DexExpectStepKind)
+* [DexExpectStepOrder](Commands.md#DexExpectStepOrder)
+* [DexExpectWatchValue](Commands.md#DexExpectWatchValue)
+* [DexUnreachable](Commands.md#DexUnreachable)
+* [DexWatch](Commands.md#DexWatch)
+
+---
+## DexExpectProgramState
+    DexExpectProgramState(state [,**times])
+
+    Args:
+        state (dict): { 'frames': [
+                        {
+                          # StackFrame #
+                          'function': name (str),
+                          'is_inlined': bool,
+                          'location': {
+                            # SourceLocation #
+                            'lineno': int,
+                            'path': str,
+                            'column': int,
+                          },
+                          'watches': {
+                            expr (str): value (str),
+                          },
+                        }
+                      ]}
+
+    Keyword args:
+        times (int): Minumum number of ime this state pattern is expected to be
+            seen. Defaults to 1. Can be 0.
+
+### Description
+Expect to see a given program `state` a certain numer of `times`.
+
+When matching expected against reported states:
+* Omitted fields in `StackFrame` and `SourceLocation` dictionaries are ignored.
+* The state match fails if the results of each `expr` in `watches`
+does not match the given `value`.
+
+
+### Heuristic
+[TODO]
+
+
+---
+## DexExpectStepKind
+    DexExpectStepKind(kind, times)
+
+    Args:
+      kind (str): Expected step kind.
+      times (int): Expected number of encounters.
+
+### Description
+Expect to see a particular step `kind` a number of `times` while stepping
+through the program.
+
+`kind` must be one of: `'FUNC'`, `'FUNC_EXTERNAL'`, `'FUNC_UNKNOWN'`,
+`'FORWARD'`, `'SAME'`, `'BACKWARD'`, `'UNKNOWN'`.
+
+### Heuristic
+[TODO]
+
+
+---
+## DexExpectStepOrder
+    DexExpectStepOrder(index)
+
+    Args:
+      index (int): Position in sequence of DexExpectStepOrder commands
+
+### Description
+Expect the line this command is found on to be stepped on before all other
+DexExpectStepOrder commands with a greater `index` argument.
+
+### Heuristic
+[TODO]
+
+
+---
+## DexExpectWatchValue
+    DexExpectWatchValue(expr, *values[,**from_line=1][,**to_line=Max]
+                        [,**on_line])
+
+    Args:
+        expr (str): C++ expression to evaluate.
+
+    Arg list:
+        values (str): At least one expected value. NOTE: string type.
+
+    Keyword args:
+        from_line (int): Evaluate the expression from this line. Defaults to 1.
+        to_line (int): Evaluate the expression to this line. Defaults to end of
+            source.
+        on_line (int): Only evaluate the expression on this line. If provided,
+            this overrides from_line and to_line.
+
+### Description
+Expect the C++ expression `expr` to evaluate to the list of `values`
+sequentially.
+
+### Heuristic
+[TODO]
+
+
+---
+## DexUnreachable
+    DexUnreachable()
+
+### Description
+Expect the source line this is found on will never be stepped on to.
+
+### Heuristic
+[TODO]
+
+
+----
+## DexLabel
+    DexLabel(name)
+
+    Args:
+        name (str): A unique name for this line.
+
+### Description
+Name the line this command is found on. Line names can be referenced by other
+commands expecting line number arguments.
+For example, `DexExpectWatchValues(..., on_line='my_line_name')`.
+
+### Heuristic
+This command does not contribute to the heuristic score.
+
+
+---
+## DexWatch
+    DexWatch(*expressions)
+
+    Arg list:
+        expressions (str): C++ `expression` to evaluate on this line.
+
+### Description
+Evaluate the `expressions` on the line this command is found on. Use in
+combination with `annotate-expected-values` to generate `DexExpectWatchValues`
+commands for this source file.
+
+### Heuristic
+This command is only used to help generate `DexExpectWatchValues`. It does not
+contribute to the heuristic score.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ The sample test case (tests/nostdlib/fibonacci) looks like this:
     29. DexExpectWatchValue('i', '0', '1', '2', '3', '4',
     30.                     from_line='start', to_line='end')
     31. DexExpectWatchValue('first', '0', '1', '2', '3', '5',
-    32.                    from_line='start', to_line='end')
+    32.                     from_line='start', to_line='end')
     33. DexExpectWatchValue('second', '1', '2', '3', '5',
-    34                      rom_line='start', to_line='end')
+    34                      from_line='start', to_line='end')
     35. DexExpectWatchValue('total', '0', '1', '2', '4', '7',
     36.                     from_line='start', to_line='end')
     37. DexExpectWatchValue('next', '1', '2', '3', '5', '8',

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ The following command evaluates your environment, listing the available and comp
 
 ### Python 3.6
 
-DExTer requires at least python 3.6. This means that LLDB must also be built
-with at least 3.6 if you wish to use it.
+DExTer requires python version 3.6 or greater.
 
 ### pywin32 python package
 

--- a/dex/builder/Builder.py
+++ b/dex/builder/Builder.py
@@ -66,6 +66,13 @@ def _get_script_environment(source_files, compiler_options,
 def run_external_build_script(context, script_path, source_files,
                               compiler_options, linker_options,
                               executable_file):
+    """Build an executable using a builder script.
+
+    The executable is saved to `context.working_directory.path`.
+
+    Returns:
+        ( stdout (str), stderr (str), builder (BuilderIR) )
+    """
 
     builderIR = BuilderIR(
         name=context.options.builder,

--- a/dex/builder/ParserOptions.py
+++ b/dex/builder/ParserOptions.py
@@ -29,6 +29,11 @@ from dex.utils import is_native_windows
 
 
 def _find_build_scripts():
+    """Finds build scripts in the 'scripts' subdirectory.
+
+    Returns:
+        { script_name (str): directory (str) }
+    """
     try:
         return _find_build_scripts.cached
     except AttributeError:

--- a/dex/command/CommandBase.py
+++ b/dex/command/CommandBase.py
@@ -51,6 +51,16 @@ class CommandBase(object, metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def eval(self):
+        """Evaluate the command.
+
+        This will be called when constructing a Heuristic object to determine
+        the debug score.
+
+        Returns:
+            The logic for handling the result of CommandBase.eval() must be
+            defined in Heuristic.__init__() so a consitent return type between
+            commands is not enforced.
+        """
         pass
 
     def get_subcommands() -> dict:

--- a/dex/command/ParseCommand.py
+++ b/dex/command/ParseCommand.py
@@ -76,8 +76,12 @@ def _merge_subcommands(command_name: str, valid_commands: dict) -> dict:
     return valid_commands
 
 
-# [TODO] Update docstring after PR #32 lands
 def _eval_command(command_raw: str, valid_commands: dict) -> CommandBase:
+    """Build a command object from raw text.
+
+    Returns:
+        A dexter command object.
+    """
     command_name = _get_command_name(command_raw)
     valid_commands = _merge_subcommands(command_name, valid_commands)
     # pylint: disable=eval-used

--- a/dex/command/ParseCommand.py
+++ b/dex/command/ParseCommand.py
@@ -40,6 +40,11 @@ from dex.command.commands.DexWatch import DexWatch
 
 
 def _get_valid_commands():
+    """Return all top level DExTer test commands.
+
+    Returns:
+        { name (str): command (class) }
+    """
     return {
       DexExpectProgramState.get_name() : DexExpectProgramState,
       DexExpectStepKind.get_name() : DexExpectStepKind,
@@ -60,8 +65,10 @@ def _get_command_name(command_raw: str) -> str:
 
 
 def _merge_subcommands(command_name: str, valid_commands: dict) -> dict:
-    """Return a dict which merges valid_commands and subcommands for
-    command_name.
+    """Merge valid_commands and command_name's subcommands into a new dict.
+
+    Returns:
+        { name (str): command (class) }
     """
     subcommands = valid_commands[command_name].get_subcommands()
     if subcommands:
@@ -69,6 +76,7 @@ def _merge_subcommands(command_name: str, valid_commands: dict) -> dict:
     return valid_commands
 
 
+# [TODO] Update docstring after PR #32 lands
 def _eval_command(command_raw: str, valid_commands: dict) -> CommandBase:
     command_name = _get_command_name(command_raw)
     valid_commands = _merge_subcommands(command_name, valid_commands)
@@ -100,8 +108,11 @@ def resolve_labels(command: CommandBase, commands: dict):
 
 
 def _find_start_of_command(line, valid_commands) -> int:
-    """Scan line for a valid command, return the index of the first character
-    of the command and the command. Return -1 if no command is found.
+    """Scan `line` for a string matching any key in `valid_commands`.
+
+    Returns:
+        int: the index of the first character of the matching string in `line`
+        or -1 if no command is found.
     """
     for command in valid_commands:
         start = line.rfind(command)
@@ -111,9 +122,24 @@ def _find_start_of_command(line, valid_commands) -> int:
 
 
 def _find_end_of_command(line, start, paren_balance) -> (int, int):
-    """Return (end, paren_balance) where end is 1 + the index of the last char
-    in the command or, if the parentheses are not balanced, the end of the line.
-    paren_balance will be 0 when the parentheses are balanced.
+    """Find the end of a command by looking for balanced parentheses.
+
+    Args:
+        line (str): String to scan.
+        start (int): Index into `line` to start looking.
+        paren_balance(int): paren_balance after previous call.
+
+    Note:
+        On the first call `start` should point at the opening parenthesis and
+        `paren_balance` should be set to 0. Subsequent calls should pass in the
+        returned `paren_balance`.
+
+    Returns:
+        ( end (int), paren_balance (int) )
+        Where end is 1 + the index of the last char in the command or, if the
+        parentheses are not balanced, the end of the line.
+
+        paren_balance will be 0 when the parentheses are balanced.
     """
     for end in range(start, len(line)):
         ch = line[end]

--- a/dex/command/commands/DexExpectProgramState.py
+++ b/dex/command/commands/DexExpectProgramState.py
@@ -42,6 +42,13 @@ def state_from_dict(source: dict) -> ProgramState:
     return ProgramState(**source)
 
 class DexExpectProgramState(CommandBase):
+    """Expect to see a given program `state` a certain numer of `times`.
+
+    DexExpectProgramState(state [,**times])
+
+    See Commands.md for more info.
+    """
+
     def __init__(self, *args, **kwargs):
         if len(args) != 1:
             raise TypeError('expected exactly one unnamed arg')

--- a/dex/command/commands/DexExpectStepKind.py
+++ b/dex/command/commands/DexExpectStepKind.py
@@ -27,6 +27,14 @@ from dex.dextIR.StepIR import StepKind
 
 
 class DexExpectStepKind(CommandBase):
+    """Expect to see a particular step `kind` a number of `times` while stepping
+    through the program.
+
+    DexExpectStepKind(kind, times)
+
+    See Commands.md for more info.
+    """
+
     def __init__(self, *args):
         if len(args) != 2:
             raise TypeError('expected two args')
@@ -47,4 +55,7 @@ class DexExpectStepKind(CommandBase):
         return __class__.__name__
 
     def eval(self):
+        # DexExpectStepKind eval() implementation is mixed into
+        # Heuristic.__init__()
+        # [TODO] Fix this ^.
         pass

--- a/dex/command/commands/DexExpectStepOrder.py
+++ b/dex/command/commands/DexExpectStepOrder.py
@@ -2,6 +2,14 @@ from dex.command.CommandBase import CommandBase
 from dex.dextIR import ValueIR
 
 class DexExpectStepOrder(CommandBase):
+    """Expect the line this command is found on to be stepped on before all
+    other DexExpectStepOrder commands with a greater `index` argument.
+
+    DexExpectStepOrder(index)
+
+    See Commands.md for more info.
+    """
+
     def __init__(self, *args):
         if not args:
             raise TypeError('Need at least one order number')

--- a/dex/command/commands/DexExpectStepOrder.py
+++ b/dex/command/commands/DexExpectStepOrder.py
@@ -2,10 +2,10 @@ from dex.command.CommandBase import CommandBase
 from dex.dextIR import ValueIR
 
 class DexExpectStepOrder(CommandBase):
-    """Expect the line this command is found on to be stepped on before all
-    other DexExpectStepOrder commands with a greater `index` argument.
+    """Expect the line every `DexExpectStepOrder` is found on to be stepped on
+    in `order`. Each instance must have a set of unique ascending indicies.
 
-    DexExpectStepOrder(index)
+    DexExpectStepOrder(*order)
 
     See Commands.md for more info.
     """

--- a/dex/command/commands/DexExpectWatchValue.py
+++ b/dex/command/commands/DexExpectWatchValue.py
@@ -81,6 +81,15 @@ def _check_watch_order(actual_watches, expected_values):
 
 
 class DexExpectWatchValue(CommandBase):
+    """Expect the C++ expression `expr` to evaluate to the list of `values`
+    sequentially.
+
+    DexExpectWatchValue(expr, *values [,**from_line=1][,**to_line=Max]
+                        [,**on_line])
+
+    See Commands.md for more info.
+    """
+
     def __init__(self, *args, **kwargs):
         if len(args) < 2:
             raise TypeError('expected at least two args')

--- a/dex/command/commands/DexUnreachable.py
+++ b/dex/command/commands/DexUnreachable.py
@@ -25,7 +25,15 @@
 from dex.command.CommandBase import CommandBase
 from dex.dextIR import ValueIR
 
+
 class DexUnreachable(CommandBase):
+    """Expect the source line this is found on will never be stepped on to.
+
+    DexUnreachable()
+
+    See Commands.md for more info.
+    """
+
     def __init(self):
         super(DexUnreachable, self).__init__()
         pass

--- a/dex/command/commands/DexWatch.py
+++ b/dex/command/commands/DexWatch.py
@@ -28,6 +28,15 @@ from dex.command.CommandBase import CommandBase
 
 
 class DexWatch(CommandBase):
+    """Evaluate the `expressions` on the line this command is found on. Use in
+    combination with `annotate-expected-values` to generate
+    `DexExpectWatchValues` commands for this source file.
+
+    DexWatch(*expressions)
+
+    See Commands.md for more info.
+    """
+
     def __init__(self, *args):
         if not args:
             raise TypeError('expected some arguments')

--- a/dex/debugger/Debuggers.py
+++ b/dex/debugger/Debuggers.py
@@ -217,7 +217,6 @@ class Debuggers(object):
             return cls._potential_debuggers
         except AttributeError:
             cls._potential_debuggers = _get_potential_debuggers()
-            import pdb; pdb.set_trace()
             return cls._potential_debuggers
 
     def __init__(self, context):

--- a/dex/debugger/Debuggers.py
+++ b/dex/debugger/Debuggers.py
@@ -43,6 +43,10 @@ from dex.debugger.visualstudio.VisualStudio2017 import VisualStudio2017
 
 
 def _get_potential_debuggers():  # noqa
+    """Return a dict of the supported debuggers.
+    Returns:
+        { name (str): debugger (class) }
+    """
     return {
         LLDB.get_option_name(): LLDB,
         VisualStudio2015.get_option_name(): VisualStudio2015,
@@ -59,7 +63,7 @@ def _warn_meaningless_option(context, option):
          '--debugger={}'.format(context.options.debugger))
 
 
-def add_debugger_tool_arguments1(parser, defaults):
+def add_debugger_tool_base_arguments(parser, defaults):
     defaults.lldb_executable = 'lldb.exe' if is_native_windows() else 'lldb'
     parser.add_argument(
         '--lldb-executable',
@@ -74,7 +78,7 @@ def add_debugger_tool_arguments(parser, context, defaults):
     debuggers = Debuggers(context)
     potential_debuggers = sorted(debuggers.potential_debuggers().keys())
 
-    add_debugger_tool_arguments1(parser, defaults)
+    add_debugger_tool_base_arguments(parser, defaults)
 
     parser.add_argument(
         '--debugger',
@@ -110,7 +114,7 @@ def add_debugger_tool_arguments(parser, context, defaults):
         help='target architecture')
 
 
-def handle_debugger_tool_options1(context, defaults):  # noqa
+def handle_debugger_tool_base_options(context, defaults):  # noqa
     options = context.options
 
     if options.lldb_executable is None:
@@ -128,7 +132,7 @@ def handle_debugger_tool_options1(context, defaults):  # noqa
 def handle_debugger_tool_options(context, defaults):  # noqa
     options = context.options
 
-    handle_debugger_tool_options1(context, defaults)
+    handle_debugger_tool_base_options(context, defaults)
 
     if options.arch is None:
         options.arch = defaults.arch
@@ -213,6 +217,7 @@ class Debuggers(object):
             return cls._potential_debuggers
         except AttributeError:
             cls._potential_debuggers = _get_potential_debuggers()
+            import pdb; pdb.set_trace()
             return cls._potential_debuggers
 
     def __init__(self, context):

--- a/dex/dextIR/BuilderIR.py
+++ b/dex/dextIR/BuilderIR.py
@@ -20,13 +20,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of information related to the builder."""
-
-
-from typing import List
 
 
 class BuilderIR:
+    """Data class which represents the compiler related options passed to Dexter
+    """
+
     def __init__(self, name: str, cflags: str, ldflags: str):
         self.name = name
         self.cflags = cflags

--- a/dex/dextIR/DebuggerIR.py
+++ b/dex/dextIR/DebuggerIR.py
@@ -20,10 +20,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of information related to the debugger itself."""
 
 
 class DebuggerIR:
+    """Data class which represents a debugger."""
+
     def __init__(self, name: str, version: str):
         self.name = name
         self.version = version

--- a/dex/dextIR/DextIR.py
+++ b/dex/dextIR/DextIR.py
@@ -20,8 +20,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Root for dextIR serialization types."""
-
 from collections import OrderedDict
 from typing import List
 
@@ -41,7 +39,19 @@ def _step_kind_func(context, step):
 
 
 class DextIR:
-    # commands: OrderedDict[str, list[CommandIR]]
+    """A full Dexter test report.
+
+    This is composed of all the other *IR classes. They are used together to
+    record Dexter inputs and the resultant debugger steps, providing a single
+    high level access container.
+
+    The Heuristic class works with dexter commands and the generated DextIR to
+    determine the debugging score for a given test.
+
+    Args:
+        commands: { name (str), commands (list[CommandIR])
+    """
+
     def __init__(self,
                  dexter_version: str,
                  executable_path: str,

--- a/dex/dextIR/FrameIR.py
+++ b/dex/dextIR/FrameIR.py
@@ -20,12 +20,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of information related to a call frame."""
-
 from dex.dextIR.LocIR import LocIR
 
 
 class FrameIR:
+    """Data class which represents a frame in the call stack"""
+
     def __init__(self, function: str, is_inlined: bool, loc: LocIR):
         self.function = function
         self.is_inlined = is_inlined

--- a/dex/dextIR/LocIR.py
+++ b/dex/dextIR/LocIR.py
@@ -20,12 +20,12 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of information related to a source location."""
-
 import os
 
 
 class LocIR:
+    """Data class which represents a source location."""
+
     def __init__(self, path: str, lineno: int, column: int):
         if path:
             path = os.path.normcase(path)

--- a/dex/dextIR/StepIR.py
+++ b/dex/dextIR/StepIR.py
@@ -20,7 +20,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of information related to a debugger step."""
+"""Classes which are used to represent debugger steps."""
 
 import json
 
@@ -51,7 +51,12 @@ class StepKind(Enum):
 
 
 class StepIR:
-    # watches: OrderedDict[string, ValueIR]
+    """A debugger step.
+
+    Args:
+        watches (OrderedDict): { expression (str), result (ValueIR) }
+    """
+
     def __init__(self,
                  step_index: int,
                  stop_reason: StopReason,

--- a/dex/dextIR/ValueIR.py
+++ b/dex/dextIR/ValueIR.py
@@ -20,12 +20,11 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-"""Serialization of information related to the result of an expression
-evaluation.
-"""
 
 
 class ValueIR:
+    """Data class to store the result of an expression evaluation."""
+
     def __init__(self,
                  expression: str,
                  value: str,

--- a/dex/tools/Main.py
+++ b/dex/tools/Main.py
@@ -185,6 +185,9 @@ def tool_main(context, tool, args):
 
 
 class Context(object):
+    """Context encapsulates globally useful objects and data; passed to many
+    Dexter functions.
+    """
 
     def __init__(self):
         self.o: PrettyOutput = None
@@ -192,6 +195,7 @@ class Context(object):
         self.options: dict = None
         self.version: str = None
         self.root_directory: str = None
+
 
 def main() -> ReturnCode:
 

--- a/dex/tools/list_debuggers/Tool.py
+++ b/dex/tools/list_debuggers/Tool.py
@@ -22,8 +22,8 @@
 # THE SOFTWARE.
 """List debuggers tool."""
 
-from dex.debugger.Debuggers import add_debugger_tool_arguments1
-from dex.debugger.Debuggers import handle_debugger_tool_options1
+from dex.debugger.Debuggers import add_debugger_tool_base_arguments
+from dex.debugger.Debuggers import handle_debugger_tool_base_options
 from dex.debugger.Debuggers import Debuggers
 from dex.tools import ToolBase
 from dex.utils import Timer
@@ -42,10 +42,10 @@ class Tool(ToolBase):
 
     def add_tool_arguments(self, parser, defaults):
         parser.description = Tool.__doc__
-        add_debugger_tool_arguments1(parser, defaults)
+        add_debugger_tool_base_arguments(parser, defaults)
 
     def handle_options(self, defaults):
-        handle_debugger_tool_options1(self.context, defaults)
+        handle_debugger_tool_base_options(self.context, defaults)
 
     def go(self) -> ReturnCode:
         with Timer('list debuggers'):

--- a/dex/tools/test/Tool.py
+++ b/dex/tools/test/Tool.py
@@ -157,7 +157,7 @@ class Tool(TestToolBase):
 
     def _get_results_path(self, test_name):
         """Returns the path to the test results directory for the test denoted
-           by test_name.
+        by test_name.
         """
         return os.path.join(self.context.options.results_directory,
                             self._get_results_basename(test_name))
@@ -176,7 +176,7 @@ class Tool(TestToolBase):
 
     def _record_steps(self, test_name, steps):
         """Write out the set of steps out to the test's .txt and .json
-           results file.
+        results file.
         """
         output_text_path = self._get_results_text_path(test_name)
         with open(output_text_path, 'w') as fp:
@@ -195,21 +195,21 @@ class Tool(TestToolBase):
 
     def _record_test_and_display(self, test_case):
         """Output test case to o stream and record test case internally for
-           handling later.
+        handling later.
         """
         self.context.o.auto(test_case)
         self._test_cases.append(test_case)
 
     def _record_failed_test(self, test_name, exception):
         """Instantiate a failed test case with failure exception and
-           store internally.
+        store internally.
         """
         test_case = TestCase(self.context, test_name, None, exception)
         self._record_test_and_display(test_case)
 
     def _record_successful_test(self, test_name, steps, heuristic):
         """Instantiate a successful test run, store test for handling later.
-           Display verbose output for test case if required.
+        Display verbose output for test case if required.
         """
         test_case = TestCase(self.context, test_name, heuristic, None)
         self._record_test_and_display(test_case)
@@ -219,7 +219,7 @@ class Tool(TestToolBase):
 
     def _run_test(self, test_dir):
         """Attempt to run test case found in test_dir. Store result internally
-           in self._test_cases.
+        in self._test_cases.
         """
         test_name = self._get_test_name(test_dir)
         try:

--- a/dex/utils/ReturnCode.py
+++ b/dex/utils/ReturnCode.py
@@ -1,5 +1,9 @@
 from enum import Enum
+
+
 class ReturnCode(Enum):
+   """Used to indicate whole program success status."""
+
    OK = 0
    _ERROR = 1        # Unhandled exceptions result in exit(1) by default.
                      # Usage of _ERROR is discouraged:


### PR DESCRIPTION
Update README.md - it was fairly out of date.

Add Command.md - document which covers Dexter commands for users (test writers)

Improve docstrings - Use "Google style" ish docstrings to better document as
much of Dexter as possible.

There is some very minor code clean up in places which could help self
documentation, eg function names.

Note:
I've written this as if PR #33 and #37 have landed.