### PR TITLE
Fix help subtool

### DIFF
--- a/dex/tools/Main.py
+++ b/dex/tools/Main.py
@@ -84,7 +84,7 @@ def get_tool_names():
     """
     return [
         'annotate-expected-values', 'clang-opt-bisect', 'help',
-        'list-debuggers', 'no-tool', 'run-debugger-internal-', 'test', 'view'
+        'list-debuggers', 'no-tool-', 'run-debugger-internal-', 'test', 'view'
     ]
 
 

--- a/dex/tools/help/Tool.py
+++ b/dex/tools/help/Tool.py
@@ -68,7 +68,7 @@ class Tool(ToolBase):
     def go(self) -> ReturnCode:
         if self.context.options.tool is None:
             self.context.o.auto(self._default_text)
-            return 0
+            return ReturnCode.OK
 
         tool_name = self.context.options.tool.replace('-', '_')
         tools_directory = get_tools_directory()


### PR DESCRIPTION
The command:

    $ dexter.py help

was throwing an exception because the tool name in get_tool_names() didn't match
the tool's folder name.

    no-tool -> no-tool-

NOTE: The dashes '-' are converted to underscores '_' later.

The help subtool go() function now returns a ReturnCode to match all other
subtools (and to prevent another exception!).