### PR TITLE
Provide warning if command is not immediately proceeded by '('

### DIFF
--- a/dex/debugger/Debuggers.py
+++ b/dex/debugger/Debuggers.py
@@ -144,7 +144,7 @@ def handle_debugger_tool_options(context, defaults):  # noqa
 
 
 def _get_command_infos(context):
-    commands = find_all_commands(context.options.source_files)
+    commands = find_all_commands(context, context.options.source_files)
     command_infos = OrderedDict()
     for command_type in commands:
         for command in commands[command_type].values():


### PR DESCRIPTION
Without this patch, parsing 'command_name (' will cause an exception.

This change means the offending command will be ignored and a helpful warning
will be given.

Doing this instead of just ignoring the whitespace lets us refer to commands
in a test file without the command being parsed.

Note: Warnings can be suppresed with -w.

NOTE: Without a larger change/refactor I'm not sure how to make this less ugly.