### PR TITLE
Use lit to drive unit and lint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,13 +311,20 @@ For clang-based compilers, the `clang-opt-bisect` tool can be used to get a brea
 
 
 ## Contributing to DExTer
-[TODO] Add new testing policy info
 
-Before submitting any contributions please ensure that all unit tests and style/lint checks still pass. These can be run with the following command line flags:
-
-    dexter.py --unittest=show-failures --lint=full --time-report
+Before submitting any contributions please ensure that all tests and style/lint checks still pass.
 
 The command line to install the packages required for style and lint checking is:
 
     <python-executable> -m pip install pycodestyle pylama pylint yapf
 
+You will need [llvm-lit][0]. It can be built with llvm or installed as `lit` by
+by running:
+
+    python -m pip install lit
+
+[0]: https://llvm.org/docs/CommandGuide/lit.html
+
+The full test suite can be run with this command:
+
+    <lit-script> feature_tests

--- a/dex/tools/ToolBase.py
+++ b/dex/tools/ToolBase.py
@@ -99,7 +99,7 @@ class ToolBase(object, metaclass=abc.ABCMeta):
             '--unittest',
             type=str,
             choices=['off', 'show-failures', 'show-all'],
-            default='show-failures',
+            default='off',
             help='run the DExTer codebase unit tests')
 
         suppress = ExtArgParse.SUPPRESS  # pylint: disable=no-member

--- a/feature_tests/style/run.test
+++ b/feature_tests/style/run.test
@@ -1,0 +1,7 @@
+Purpose:
+    Run DExTer style tests.
+
+# lint=full takes a long time.
+# TODO: Fix all style issues in DExTer.
+RUN: dexter.py --lint=fast 2>&1 | FileCheck %s
+CHECK-NOT: error:

--- a/feature_tests/unittests/run.test
+++ b/feature_tests/unittests/run.test
@@ -1,0 +1,9 @@
+Purpose:
+    Run DExTer unit tests.
+
+# Dexter returns 1 when no subtools are specified.
+RUN: not dexter.py --unittest=show-all 2>&1 | FileCheck %s
+
+CHECK: Ran {{[0-9]+}} tests
+CHECK-EMPTY:
+CHECK-NEXT: OK


### PR DESCRIPTION
This patch unifies the testing interface; all tests can be run through
llvm-lit.

This makes it easier to run all the tests.

--unittest=off is now default so that unit tests are not run every
time DExTer is used.

The documentation has been updated to reflect these changes.