### PR TITLE
Set SUBSYSTEM:WINDOWS as the default environment on Windows

### DIFF
--- a/dex/builder/scripts/windows/clang-cl_vs2015.bat
+++ b/dex/builder/scripts/windows/clang-cl_vs2015.bat
@@ -11,7 +11,7 @@ for %%I in (%SOURCE_INDEXES%) do (
   if errorlevel 1 goto :FAIL
 )
 
-clang-cl.exe %LINKER_OPTIONS% %OBJECT_FILES% /Fe%EXECUTABLE_FILE%
+clang-cl.exe %OBJECT_FILES% /Fe%EXECUTABLE_FILE% /link /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup %LINKER_OPTIONS%
 if errorlevel 1 goto :FAIL
 goto :END
 

--- a/dex/builder/scripts/windows/clang.bat
+++ b/dex/builder/scripts/windows/clang.bat
@@ -5,7 +5,7 @@ for %%I in (%SOURCE_INDEXES%) do (
   if errorlevel 1 goto :FAIL
 )
 
-clang++.exe -fuse-ld=lld %LINKER_OPTIONS% %OBJECT_FILES% -o %EXECUTABLE_FILE%
+clang++.exe -fuse-ld=lld %OBJECT_FILES% -o %EXECUTABLE_FILE% -Wl,-subsystem:windows,-ENTRY:mainCRTStartup %LINKER_OPTIONS%
 if errorlevel 1 goto :FAIL
 goto :END
 


### PR DESCRIPTION
At the moment a console window is created when a DExTer test case is started up
for debugging on Windows. This is an undesirable default behaviour because the
test cases will steal focus every time they are run.

The default subsystem for programs with a 'main' entry point is CONSOLE.
Linking with /SUBSYSTEM:WINDOWS means the application will not create a console
when it runs.

/ENTRY:mainCRTStartup is now required because setting /SUBSYSTEM:WINDOWS tells
the linker to look for 'WinMain' by default instead of 'main'.

These compiler flags are overridable by providing them explicitly through
DExTer's --cflags and --ldflags.