### PR TITLE
Fix missing FileCheck from feature_tests/subtools/

### DIFF
--- a/feature_tests/subtools/help/help.test
+++ b/feature_tests/subtools/help/help.test
@@ -1,9 +1,11 @@
 Purpose:
     Check the `help` subtool runs.
 
-RUN: dexter.py help
+RUN: dexter.py help | FileCheck %s
 CHECK: The following subtools are available:
-CHECK-DAG: help
-CHECK-DAG: test
-CHECK-DAG: annotate-expected-values
-CHECK-DAG: view
+CHECK: annotate-expected-values
+CHECK: clang-opt-bisect
+CHECK: help
+CHECK: list-debuggers
+CHECK: test
+CHECK: view

--- a/feature_tests/subtools/list-debuggers/list-debuggers.test
+++ b/feature_tests/subtools/list-debuggers/list-debuggers.test
@@ -1,7 +1,7 @@
 Purpose:
     Check the `list-debuggers` subtool runs.
 
-RUN: dexter.py list-debuggers
+RUN: dexter.py list-debuggers | FileCheck %s
 CHECK: lldb
 CHECK: vs2015
 CHECK: vs2017


### PR DESCRIPTION
These tests in feature_tests/subtools have FileCheck directives but were not
using FileCheck:

/help
  - Added missing subtools.
  - Require specific order because it would be unexpected to see a change here.

/list-debuggers