### PR TITLE
Prevent FileExistsError when creating results and working directories

### DIFF
--- a/dex/tools/TestToolBase.py
+++ b/dex/tools/TestToolBase.py
@@ -103,7 +103,7 @@ class TestToolBase(ToolBase):
         options.results_directory = os.path.abspath(options.results_directory)
         if not os.path.isdir(options.results_directory):
             try:
-                os.makedirs(options.results_directory)
+                os.makedirs(options.results_directory, exist_ok=True)
             except OSError as e:
                 raise Error(
                     '<d>could not create directory</> <r>"{}"</> <y>({})</>'.

--- a/dex/utils/WorkingDirectory.py
+++ b/dex/utils/WorkingDirectory.py
@@ -37,7 +37,7 @@ class WorkingDirectory(object):
 
         dir_ = kwargs.get('dir', None)
         if dir_ and not os.path.isdir(dir_):
-            os.makedirs(dir_)
+            os.makedirs(dir_, exist_ok=True)
         self.path = tempfile.mkdtemp(*args, **kwargs)
 
     def __enter__(self):


### PR DESCRIPTION
It is clear from the surrounding code that the intent is to only create the
'working directory' if it doesn't already exist (i.e. using an existing
directory is okay). However, without this patch, if multiple dexter instances
try to create the directory simultaneously one will raise FileExistsError.