### PR TITLE
Revert "Set SUBSYSTEM:WINDOWS as the default environment on Windows (…

### DIFF
--- a/dex/builder/scripts/windows/clang-cl_vs2015.bat
+++ b/dex/builder/scripts/windows/clang-cl_vs2015.bat
@@ -11,7 +11,7 @@ for %%I in (%SOURCE_INDEXES%) do (
   if errorlevel 1 goto :FAIL
 )
 
-clang-cl.exe %OBJECT_FILES% /Fe%EXECUTABLE_FILE% /link /SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup %LINKER_OPTIONS%
+clang-cl.exe %LINKER_OPTIONS% %OBJECT_FILES% /Fe%EXECUTABLE_FILE%
 if errorlevel 1 goto :FAIL
 goto :END
 

--- a/dex/builder/scripts/windows/clang.bat
+++ b/dex/builder/scripts/windows/clang.bat
@@ -5,7 +5,7 @@ for %%I in (%SOURCE_INDEXES%) do (
   if errorlevel 1 goto :FAIL
 )
 
-clang++.exe -fuse-ld=lld %OBJECT_FILES% -o %EXECUTABLE_FILE% -Wl,-subsystem:windows,-ENTRY:mainCRTStartup %LINKER_OPTIONS%
+clang++.exe -fuse-ld=lld %LINKER_OPTIONS% %OBJECT_FILES% -o %EXECUTABLE_FILE%
 if errorlevel 1 goto :FAIL
 goto :END
 


### PR DESCRIPTION
…#54)"

This reverts commit d370454790545316ce92c22e7a2bdc754cd8bda7. There are two
problems with the patch.

Before d370454, --ldflags args were passed to the compiler driver (e.g.
clang-cl.exe). With d370454 they are passed after /link, which means /Zi in
--ldflags gets ignored and no debug data is generated for windows targets.

/SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup isn't cross-compile friendly.