### PR TITLE
Dbgeng fixes2

### DIFF
--- a/dex/debugger/dbgeng/control.py
+++ b/dex/debugger/dbgeng/control.py
@@ -22,10 +22,10 @@ PDEBUG_STACK_FRAME_EX = POINTER(DEBUG_STACK_FRAME_EX)
 
 class DEBUG_VALUE_U(Union):
   _fields_ = [
-      ("I8", c_ubyte),
-      ("I16", c_ushort),
-      ("I32", c_ulong),
-      ("I64", c_ulong), # slight hack
+      ("I8", c_byte),
+      ("I16", c_short),
+      ("I32", c_int),
+      ("I64", c_long),
       ("F32", c_float),
       ("F64", c_double),
       ("RawBytes", c_ubyte * 24) # Force length to 24b.
@@ -359,7 +359,8 @@ class Control(object):
 
     val_type = DebugValueType(ptr.Type)
 
-    # Here's a map from debug value types to fields
+    # Here's a map from debug value types to fields. Unclear what happens
+    # with unsigned values, as DbgEng doesn't present any unsigned fields.
 
     extract_map = {
       DebugValueType.DEBUG_VALUE_INT8    : ("I8", "char"),

--- a/dex/debugger/dbgeng/dbgeng.py
+++ b/dex/debugger/dbgeng/dbgeng.py
@@ -155,4 +155,4 @@ class DbgEng(DebuggerBase):
             error_string="",
             could_evaluate=could_eval,
             is_optimized_away=False,
-            is_irretrievable=False)
+            is_irretrievable=not could_eval)

--- a/dex/debugger/dbgeng/dbgeng.py
+++ b/dex/debugger/dbgeng/dbgeng.py
@@ -143,7 +143,9 @@ class DbgEng(DebuggerBase):
         # as it appears to reserve '.' for other purposes.
         fixed_expr = expression.replace('.', '->')
 
-        # TODO: evaluate expressions in the right stack frame?
+        orig_scope_idx = self.client.Symbols.GetCurrentScopeFrameIndex()
+        self.client.Symbols.SetScopeFrameByIndex(frame_idx)
+
         res = self.client.Control.Evaluate(fixed_expr)
         if res is not None:
           result, typename = self.client.Control.Evaluate(fixed_expr)
@@ -151,6 +153,8 @@ class DbgEng(DebuggerBase):
         else:
           result, typename = (None, None)
           could_eval = False
+
+        self.client.Symbols.SetScopeFrameByIndex(orig_scope_idx)
 
         return ValueIR(
             expression=expression,

--- a/dex/debugger/dbgeng/dbgeng.py
+++ b/dex/debugger/dbgeng/dbgeng.py
@@ -139,10 +139,14 @@ class DbgEng(DebuggerBase):
         return self.finished
 
     def evaluate_expression(self, expression, frame_idx=0):
+        # XXX: cdb insists on using '->' to examine fields of structures,
+        # as it appears to reserve '.' for other purposes.
+        fixed_expr = expression.replace('.', '->')
+
         # TODO: evaluate expressions in the right stack frame?
-        res = self.client.Control.Evaluate(expression)
+        res = self.client.Control.Evaluate(fixed_expr)
         if res is not None:
-          result, typename = self.client.Control.Evaluate(expression)
+          result, typename = self.client.Control.Evaluate(fixed_expr)
           could_eval = True
         else:
           result, typename = (None, None)


### PR DESCRIPTION
Additional fixes for dbgeng -- it was reading signed values as unsigned, and never set is_irretrievable for an evaluated expression correctly. Test for this is a cdb test I've converted to dexter, which will turn up somewhere else.