### PR TITLE
Use WINFUNCTYPE for windows callback types

### DIFF
--- a/dex/debugger/dbgeng/breakpoint.py
+++ b/dex/debugger/dbgeng/breakpoint.py
@@ -23,7 +23,7 @@ class DebugBreakpoint2(Structure):
   pass
 
 class DebugBreakpoint2Vtbl(Structure):
-  wrp = partial(CFUNCTYPE, c_long, POINTER(DebugBreakpoint2))
+  wrp = partial(WINFUNCTYPE, c_long, POINTER(DebugBreakpoint2))
   idb_setoffset = wrp(c_ulonglong)
   idb_setflags = wrp(c_ulong)
   _fields_ = [

--- a/dex/debugger/dbgeng/client.py
+++ b/dex/debugger/dbgeng/client.py
@@ -23,7 +23,7 @@ class IDebugClient7(Structure):
   pass
 
 class IDebugClient7Vtbl(Structure):
-  wrp = partial(CFUNCTYPE, c_long, POINTER(IDebugClient7))
+  wrp = partial(WINFUNCTYPE, c_long, POINTER(IDebugClient7))
   idc_queryinterface = wrp(POINTER(IID), POINTER(c_void_p))
   idc_attachprocess = wrp(c_longlong, c_long, c_long)
   idc_detachprocesses = wrp()

--- a/dex/debugger/dbgeng/control.py
+++ b/dex/debugger/dbgeng/control.py
@@ -61,7 +61,7 @@ class IDebugControl7(Structure):
   pass
 
 class IDebugControl7Vtbl(Structure):
-  wrp = partial(CFUNCTYPE, c_long, POINTER(IDebugControl7))
+  wrp = partial(WINFUNCTYPE, c_long, POINTER(IDebugControl7))
   idc_getnumbereventfilters = wrp(c_ulong_p, c_ulong_p, c_ulong_p)
   idc_setexceptionfiltersecondcommand = wrp(c_ulong, c_char_p)
   idc_waitforevent = wrp(c_long, c_long)

--- a/dex/debugger/dbgeng/symbols.py
+++ b/dex/debugger/dbgeng/symbols.py
@@ -100,7 +100,7 @@ class IDebugSymbols5(Structure):
   pass
 
 class IDebugSymbols5Vtbl(Structure):
-  wrp = partial(CFUNCTYPE, c_long, POINTER(IDebugSymbols5))
+  wrp = partial(WINFUNCTYPE, c_long, POINTER(IDebugSymbols5))
   ids_getsymboloptions = wrp(c_ulong_p)
   ids_setsymboloptions = wrp(c_ulong)
   ids_getmoduleparameters = wrp(c_ulong, c_ulong64_p, c_ulong, PDEBUG_MODULE_PARAMETERS)

--- a/dex/debugger/dbgeng/symgroup.py
+++ b/dex/debugger/dbgeng/symgroup.py
@@ -10,7 +10,7 @@ class IDebugSymbolGroup2(Structure):
   pass
 
 class IDebugSymbolGroup2Vtbl(Structure):
-  wrp = partial(CFUNCTYPE, c_long, POINTER(IDebugSymbolGroup2))
+  wrp = partial(WINFUNCTYPE, c_long, POINTER(IDebugSymbolGroup2))
   ids_getnumbersymbols = wrp(c_ulong_p)
   ids_getsymbolname = wrp(c_ulong, c_char_p, c_ulong, c_ulong_p)
   ids_getsymboltypename = wrp(c_ulong, c_char_p, c_ulong, c_ulong_p)

--- a/dex/debugger/dbgeng/sysobjs.py
+++ b/dex/debugger/dbgeng/sysobjs.py
@@ -10,7 +10,7 @@ class IDebugSystemObjects4(Structure):
   pass
 
 class IDebugSystemObjects4Vtbl(Structure):
-  wrp = partial(CFUNCTYPE, c_long, POINTER(IDebugSystemObjects4))
+  wrp = partial(WINFUNCTYPE, c_long, POINTER(IDebugSystemObjects4))
   ids_getnumberprocesses = wrp(POINTER(c_ulong))
   ids_getprocessidsbyindex = wrp(c_ulong, c_ulong, c_ulong_p, c_ulong_p)
   ids_setcurrentprocessid = wrp(c_ulong)

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -77,8 +77,9 @@ class LLDB(DebuggerBase):
     def _load_interface(self):
         try:
             args = [self.lldb_executable, '-P']
-            pythonpath = check_output(
-                args, stderr=STDOUT).rstrip().decode('utf-8')
+            #pythonpath = check_output(
+            #    args, stderr=STDOUT).rstrip().decode('utf-8')
+            pythonpath='/faster/fs/lollldb/lib/python3.6/site-packages'
         except CalledProcessError as e:
             raise LoadDebuggerException(str(e), sys.exc_info())
         except OSError as e:

--- a/dex/debugger/lldb/LLDB.py
+++ b/dex/debugger/lldb/LLDB.py
@@ -77,9 +77,8 @@ class LLDB(DebuggerBase):
     def _load_interface(self):
         try:
             args = [self.lldb_executable, '-P']
-            #pythonpath = check_output(
-            #    args, stderr=STDOUT).rstrip().decode('utf-8')
-            pythonpath='/faster/fs/lollldb/lib/python3.6/site-packages'
+            pythonpath = check_output(
+                args, stderr=STDOUT).rstrip().decode('utf-8')
         except CalledProcessError as e:
             raise LoadDebuggerException(str(e), sys.exc_info())
         except OSError as e:


### PR DESCRIPTION
WINFUNCTYPE selects the correct calling convention from the platform, if we pick cdecl all the time then windows gets upset on 32 bit machines.

stdcall: causing me misery and pain for almost 20 years!