### PR TITLE
Fix source-file detection in dbgeng

### DIFF
--- a/dex/command/ParseCommand.py
+++ b/dex/command/ParseCommand.py
@@ -25,6 +25,7 @@ subset of Python is allowed, in order to prevent the possibility of unsafe
 Python code being embedded within DExTer commands.
 """
 
+import os
 import unittest
 from copy import copy
 
@@ -109,7 +110,7 @@ def resolve_labels(command: CommandBase, commands: dict):
     command_label_args = command.get_label_args()
     for command_arg in command_label_args:
         for dex_label in list(dex_labels.values()):
-            if (dex_label.path == command.path and
+            if (os.path.samefile(dex_label.path, command.path) and
                 dex_label.eval() == command_arg):
                 command.resolve_label(dex_label.get_as_pair())
     # labels for command should be resolved by this point.

--- a/dex/command/commands/DexExpectWatchBase.py
+++ b/dex/command/commands/DexExpectWatchBase.py
@@ -184,7 +184,8 @@ class DexExpectWatchBase(CommandBase):
         for step in step_collection.steps:
             loc = step.current_location
 
-            if (os.path.samefile(loc.path, self.path) and
+            if (os.path.exists(loc.path) and os.path.exists(self.path) and
+                os.path.samefile(loc.path, self.path) and
                 loc.lineno in self.line_range):
                 try:
                     watch = step.program_state.frames[0].watches[self.expression]

--- a/dex/command/commands/DexExpectWatchBase.py
+++ b/dex/command/commands/DexExpectWatchBase.py
@@ -27,6 +27,7 @@
 
 import abc
 import difflib
+import os
 
 from dex.command.CommandBase import CommandBase
 from dex.command.StepValueInfo import StepValueInfo
@@ -183,7 +184,8 @@ class DexExpectWatchBase(CommandBase):
         for step in step_collection.steps:
             loc = step.current_location
 
-            if (loc.path == self.path and loc.lineno in self.line_range):
+            if (os.path.samefile(loc.path, self.path) and
+                loc.lineno in self.line_range):
                 try:
                     watch = step.program_state.frames[0].watches[self.expression]
                 except KeyError:

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -118,7 +118,8 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         try:
             # Iterate over all watches of the types named in watch_cmds
             for watch in towatch:
-                if (os.path.samefile(watch.path, loc.path)
+                if (os.path.exists(loc.path)
+                        and os.path.samefile(watch.path, loc.path)
                         and watch.lineno == loc.lineno):
                     result = watch.eval(self)
                     step_info.watches.update(result)
@@ -167,6 +168,8 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
 
     def in_source_file(self, step_info):
         if not step_info.current_frame:
+            return False
+        if not os.path.exists(step_info.current_location.path):
             return False
         return any(os.path.samefile(step_info.current_location.path, f) \
                    for f in self.context.options.source_files)

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -24,10 +24,10 @@
 
 import abc
 from itertools import chain
+import os
 import sys
 import time
 import traceback
-
 
 from dex.dextIR import DebuggerIR, ValueIR
 from dex.utils.Exceptions import DebuggerException
@@ -155,9 +155,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
                 self._update_step_watches(step_info)
                 self.steps.new_step(self.context, step_info)
 
-            if (step_info.current_frame
-                    and (step_info.current_location.path in
-                         self.context.options.source_files)):
+            if self.in_source_file(step_info):
                 self.step()
             else:
                 self.go()
@@ -166,6 +164,13 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         else:
             raise DebuggerException(
                 'maximum number of steps reached ({})'.format(max_steps))
+
+    def in_source_file(self, step_info):
+        if not step_info.current_frame:
+            return False
+        return any(os.path.samefile(step_info.current_location.path, f) \
+                   for f in self.context.options.source_files)
+
     @abc.abstractmethod
     def _load_interface(self):
         pass

--- a/dex/debugger/DebuggerBase.py
+++ b/dex/debugger/DebuggerBase.py
@@ -118,7 +118,7 @@ class DebuggerBase(object, metaclass=abc.ABCMeta):
         try:
             # Iterate over all watches of the types named in watch_cmds
             for watch in towatch:
-                if (watch.path == loc.path
+                if (os.path.samefile(watch.path, loc.path)
                         and watch.lineno == loc.lineno):
                     result = watch.eval(self)
                     step_info.watches.update(result)

--- a/dex/dextIR/DextIR.py
+++ b/dex/dextIR/DextIR.py
@@ -30,7 +30,8 @@ from dex.dextIR.StepIR import StepIR, StepKind
 
 
 def _step_kind_func(context, step):
-    if step.current_location.path is None:
+    if (step.current_location.path is None or
+        not os.path.exists(step.current_location.path)):
         return StepKind.FUNC_UNKNOWN
 
     if any(os.path.samefile(step.current_location.path, f)

--- a/dex/dextIR/DextIR.py
+++ b/dex/dextIR/DextIR.py
@@ -21,6 +21,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 from collections import OrderedDict
+import os
 from typing import List
 
 from dex.dextIR.BuilderIR import BuilderIR
@@ -29,11 +30,12 @@ from dex.dextIR.StepIR import StepIR, StepKind
 
 
 def _step_kind_func(context, step):
-    if step.current_location.path in context.options.source_files:
-        return StepKind.FUNC
-
     if step.current_location.path is None:
         return StepKind.FUNC_UNKNOWN
+
+    if any(os.path.samefile(step.current_location.path, f)
+           for f in context.options.source_files):
+        return StepKind.FUNC
 
     return StepKind.FUNC_EXTERNAL
 

--- a/dex/dextIR/LocIR.py
+++ b/dex/dextIR/LocIR.py
@@ -37,7 +37,8 @@ class LocIR:
         return '{}({}:{})'.format(self.path, self.lineno, self.column)
 
     def __eq__(self, rhs):
-        return (self.path == rhs.path and self.lineno == rhs.lineno
+        return (os.path.samefile(self.path, rhs.path)
+                and self.lineno == rhs.lineno
                 and self.column == rhs.column)
 
     def __lt__(self, rhs):

--- a/dex/dextIR/LocIR.py
+++ b/dex/dextIR/LocIR.py
@@ -37,7 +37,8 @@ class LocIR:
         return '{}({}:{})'.format(self.path, self.lineno, self.column)
 
     def __eq__(self, rhs):
-        return (os.path.samefile(self.path, rhs.path)
+        return (os.path.exists(self.path) and os.path.exists(rhs.path)
+                and os.path.samefile(self.path, rhs.path)
                 and self.lineno == rhs.lineno
                 and self.column == rhs.column)
 


### PR DESCRIPTION
Dbgeng coughs up very different file paths to the ones that dexter believes identifies the source files it's working on. Allow debuggers to work out whether we're currently in a source file themselve,s through overriding a DebuggerBase method.